### PR TITLE
feat: add Firebase auth middleware and user profile API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import morgan from 'morgan'
 import { errorHandler } from './middleware/errorHandler'
 import { notFound } from './middleware/notFound'
 import healthRouter from './routes/health'
+import usersRouter from './routes/users'
 
 const app = express()
 
@@ -30,6 +31,7 @@ app.use(express.urlencoded({ extended: true }))
 
 // Routes
 app.use('/api/health', healthRouter)
+app.use('/api/users', usersRouter)
 
 // Error handling (must be last)
 app.use(notFound)

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,0 +1,138 @@
+import { Request, Response, NextFunction } from 'express'
+import { FieldValue } from 'firebase-admin/firestore'
+import { adminDb } from '../lib/firebase'
+import {
+  UserProfile,
+  UserProfileResponse,
+  PublicUserProfileResponse,
+  UpdateUserBody,
+} from '../types/user'
+import { AppError } from '../middleware/errorHandler'
+
+const USERS = 'users'
+
+function toResponse(profile: UserProfile): UserProfileResponse {
+  return {
+    ...profile,
+    createdAt: profile.createdAt.toDate().toISOString(),
+    updatedAt: profile.updatedAt.toDate().toISOString(),
+  }
+}
+
+function toPublicResponse(profile: UserProfile): PublicUserProfileResponse {
+  const { email: _email, ...rest } = toResponse(profile)
+  return rest
+}
+
+// POST /api/users/me
+// Upsert profile — call this on every sign-in to sync Firebase Auth → Firestore
+export async function upsertMe(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { uid, email, name, picture } = req.user!
+    const ref = adminDb.collection(USERS).doc(uid)
+    const snap = await ref.get()
+
+    if (!snap.exists) {
+      const now = FieldValue.serverTimestamp()
+      const newProfile = {
+        uid,
+        displayName: name ?? email ?? uid,
+        email: email ?? '',
+        photoURL: picture ?? null,
+        bio: null,
+        affiliation: null,
+        scores: { designer: 0, experimenter: 0, reviewer: 0 },
+        createdAt: now,
+        updatedAt: now,
+      }
+      await ref.set(newProfile)
+      const created = await ref.get()
+      res.status(201).json({ status: 'ok', data: toResponse(created.data() as UserProfile) })
+    } else {
+      // Sync display fields from auth token on every sign-in
+      await ref.update({
+        displayName: name ?? snap.data()!.displayName,
+        email: email ?? snap.data()!.email,
+        photoURL: picture ?? snap.data()!.photoURL,
+        updatedAt: FieldValue.serverTimestamp(),
+      })
+      const updated = await ref.get()
+      res.status(200).json({ status: 'ok', data: toResponse(updated.data() as UserProfile) })
+    }
+  } catch (err) {
+    next(err)
+  }
+}
+
+// GET /api/users/me
+export async function getMe(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const snap = await adminDb.collection(USERS).doc(req.user!.uid).get()
+    if (!snap.exists) {
+      const error: AppError = new Error('Profile not found — call POST /api/users/me first')
+      error.statusCode = 404
+      return next(error)
+    }
+    res.status(200).json({ status: 'ok', data: toResponse(snap.data() as UserProfile) })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// PATCH /api/users/me
+export async function updateMe(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const ref = adminDb.collection(USERS).doc(req.user!.uid)
+    const snap = await ref.get()
+    if (!snap.exists) {
+      const error: AppError = new Error('Profile not found — call POST /api/users/me first')
+      error.statusCode = 404
+      return next(error)
+    }
+
+    const { displayName, photoURL, bio, affiliation }: UpdateUserBody = req.body
+    const patch: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() }
+    if (displayName !== undefined) patch.displayName = displayName
+    if (photoURL !== undefined) patch.photoURL = photoURL
+    if (bio !== undefined) patch.bio = bio
+    if (affiliation !== undefined) patch.affiliation = affiliation
+
+    await ref.update(patch)
+    const updated = await ref.get()
+    res.status(200).json({ status: 'ok', data: toResponse(updated.data() as UserProfile) })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// GET /api/users/:id
+export async function getUser(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const snap = await adminDb.collection(USERS).doc(req.params.id).get()
+    if (!snap.exists) {
+      const error: AppError = new Error('User not found')
+      error.statusCode = 404
+      return next(error)
+    }
+    const data = toPublicResponse(snap.data() as UserProfile)
+    res.status(200).json({ status: 'ok', data })
+  } catch (err) {
+    next(err)
+  }
+}

--- a/backend/src/lib/firebase.ts
+++ b/backend/src/lib/firebase.ts
@@ -1,0 +1,19 @@
+import * as admin from 'firebase-admin'
+
+if (!admin.apps.length) {
+  const projectId = process.env.FIREBASE_ADMIN_PROJECT_ID
+  const clientEmail = process.env.FIREBASE_ADMIN_CLIENT_EMAIL
+  const privateKey = process.env.FIREBASE_ADMIN_PRIVATE_KEY?.replace(/\\n/g, '\n')
+
+  if (projectId && clientEmail && privateKey) {
+    admin.initializeApp({
+      credential: admin.credential.cert({ projectId, clientEmail, privateKey }),
+    })
+  } else {
+    // Inside Firebase Functions — use application default credentials
+    admin.initializeApp()
+  }
+}
+
+export const adminAuth = admin.auth()
+export const adminDb = admin.firestore()

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,31 @@
+import * as admin from 'firebase-admin'
+import { Request, Response, NextFunction } from 'express'
+import { adminAuth } from '../lib/firebase'
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: admin.auth.DecodedIdToken
+    }
+  }
+}
+
+export async function requireAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const authHeader = req.headers.authorization
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({ status: 'error', message: 'Missing authorization header' })
+    return
+  }
+
+  const token = authHeader.slice(7)
+  try {
+    req.user = await adminAuth.verifyIdToken(token)
+    next()
+  } catch {
+    res.status(401).json({ status: 'error', message: 'Invalid or expired token' })
+  }
+}

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express'
+import { requireAuth } from '../middleware/auth'
+import { upsertMe, getMe, updateMe, getUser } from '../controllers/userController'
+
+const router = Router()
+
+// All /api/users routes require a valid Firebase ID token
+router.use(requireAuth)
+
+// Own profile
+router.post('/me', upsertMe)    // create or sync on sign-in
+router.get('/me', getMe)        // get full profile
+router.patch('/me', updateMe)   // update editable fields
+
+// Public profiles
+router.get('/:id', getUser)
+
+export default router

--- a/backend/src/types/user.ts
+++ b/backend/src/types/user.ts
@@ -1,0 +1,33 @@
+import { firestore } from 'firebase-admin'
+
+export interface UserScores {
+  designer: number
+  experimenter: number
+  reviewer: number
+}
+
+export interface UserProfile {
+  uid: string
+  displayName: string
+  email: string
+  photoURL: string | null
+  bio: string | null
+  affiliation: string | null
+  scores: UserScores
+  createdAt: firestore.Timestamp
+  updatedAt: firestore.Timestamp
+}
+
+export interface UserProfileResponse extends Omit<UserProfile, 'createdAt' | 'updatedAt'> {
+  createdAt: string
+  updatedAt: string
+}
+
+export type PublicUserProfileResponse = Omit<UserProfileResponse, 'email'>
+
+export interface UpdateUserBody {
+  displayName?: string
+  photoURL?: string | null
+  bio?: string | null
+  affiliation?: string | null
+}


### PR DESCRIPTION
- Firebase Admin SDK initializer (lib/firebase.ts)
- requireAuth middleware — verifies Firebase ID tokens, attaches req.user
- UserProfile types with 3-dimensional scores (designer/experimenter/reviewer)
- POST /api/users/me — upsert profile on sign-in
- GET  /api/users/me — own full profile
- PATCH /api/users/me — update editable fields (displayName, bio, affiliation, photoURL)
- GET  /api/users/:id — public profile (no email)