### PR TITLE
feat: add Firestore composite indexes and fix list query

### DIFF
--- a/backend/src/types/design.ts
+++ b/backend/src/types/design.ts
@@ -121,6 +121,7 @@ export interface Design {
 
   // Metadata (system-managed)
   status: DesignStatus
+  is_public: boolean           // true when status is 'published' or 'locked'
   version: number
   author_ids: string[]
   review_status: ReviewStatus

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+    "indexes": "firestore.indexes.json"
+  },
   "hosting": {
     "public": "frontend/dist",
     "ignore": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,49 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "designs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "is_public", "order": "ASCENDING" },
+        { "fieldPath": "created_at", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "designs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "is_public", "order": "ASCENDING" },
+        { "fieldPath": "difficulty_level", "order": "ASCENDING" },
+        { "fieldPath": "created_at", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "designs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "is_public", "order": "ASCENDING" },
+        { "fieldPath": "discipline_tags", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "created_at", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "designs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "is_public", "order": "ASCENDING" },
+        { "fieldPath": "discipline_tags", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "difficulty_level", "order": "ASCENDING" },
+        { "fieldPath": "created_at", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "designs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "author_ids", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "updated_at", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
- Add firestore.indexes.json with 5 composite indexes for the designs collection covering all filter/sort combinations used by listDesigns and listMyDesigns
- Wire firestore.indexes.json into firebase.json so indexes deploy with 'firebase deploy --only firestore:indexes'
- Add is_public boolean field to Design (true when published or locked) so list queries can use equality (==) as the base filter, which allows safe combination with array-contains on discipline_tags — Firestore prohibits 'in' + 'array-contains' in a single query