### PR TITLE
fix: add firestore.rules so Firebase CLI recognizes firestore target

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "firestore": {
+    "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
   "hosting": {

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // All reads and writes go through the backend via the Admin SDK,
+    // which bypasses these rules entirely. Direct client access is denied.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
Firebase CLI requires both 'rules' and 'indexes' keys in the firestore section of firebase.json to register it as a valid deploy target. Without a rules file, 'firebase deploy --only firestore:indexes' fails with 'No targets match'.

Rules deny all direct client access — all DB operations go through the backend via Admin SDK which bypasses security rules.