### PR TITLE
fix(backend): align .env.example var names with firebase.ts

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,9 +4,9 @@ NODE_ENV=development
 
 # Firebase Admin SDK
 # Found in: Firebase Console > Project Settings > Service Accounts > Generate new private key
-FIREBASE_PROJECT_ID=your-project-id
-FIREBASE_CLIENT_EMAIL=firebase-adminsdk-xxxx@your-project-id.iam.gserviceaccount.com
-FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+FIREBASE_ADMIN_PROJECT_ID=your-project-id
+FIREBASE_ADMIN_CLIENT_EMAIL=firebase-adminsdk-xxxx@your-project-id.iam.gserviceaccount.com
+FIREBASE_ADMIN_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
 
 # CORS — comma-separated list of allowed origins
 CORS_ORIGINS=http://localhost:5173


### PR DESCRIPTION
## Summary
- `backend/.env.example` used `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, and `FIREBASE_PRIVATE_KEY`
- `backend/src/lib/firebase.ts` actually reads `FIREBASE_ADMIN_PROJECT_ID`, `FIREBASE_ADMIN_CLIENT_EMAIL`, and `FIREBASE_ADMIN_PRIVATE_KEY`
- Following the example as written would cause Firebase Admin to silently fall back to application default credentials and fail at runtime during local dev

## Fix
Renamed the three variables in `.env.example` to match what the code reads.

## Test plan
- [ ] Copy `backend/.env.example` to `backend/.env`, fill in real values, run `npm run dev` — Firebase should initialize without errors

Closes #10

https://claude.ai/code/session_01V3gq58vdyXA8v1cmRmhnEM