### PR TITLE
fix(ci): pass --project flag to firebase deploy to resolve 'No active project' error

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -131,6 +131,7 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
 
       - name: Deploy to Firebase (hosting + functions)
-        run: firebase deploy --non-interactive
+        run: firebase deploy --non-interactive --project "$FIREBASE_PROJECT_ID"
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-sa.json
+          FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}


### PR DESCRIPTION
## Problem

Firebase deploy was failing with:

```
Error: No currently active project.
To run this command, you need to specify a project.
```

`firebase deploy --non-interactive` cannot infer the project from the service account credentials alone — it requires an explicit `--project` flag or a `.firebaserc` default.

## Fix

Added `--project "$FIREBASE_PROJECT_ID"` to the deploy command and passed the already-configured `VITE_FIREBASE_PROJECT_ID` secret as `FIREBASE_PROJECT_ID` in that step's env.

Also includes the earlier fix replacing `ts-node-dev` with `tsx` to eliminate the blocked `yn@3.1.1` dependency.

## Test plan
- [ ] Firebase deploy step completes successfully on merge to main

https://claude.ai/code/session_01V3gq58vdyXA8v1cmRmhnEM