### PR TITLE
fix(ci): remove redundant predeploy build hook to fix deploy failure

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -42,9 +42,7 @@
         "firebase-debug.log",
         "firebase-debug.*.log"
       ],
-      "predeploy": [
-        "npm --prefix backend run build"
-      ]
+      "predeploy": []
     }
   ]
 }


### PR DESCRIPTION
## Problem

Firebase deploy was failing during the predeploy hook:

```
Running command: npm --prefix backend run build
error TS7016: Could not find a declaration file for module 'morgan'.
Try `npm i --save-dev @types/morgan`
Error: functions predeploy error: Command terminated with non-zero exit code 2
```

The deploy job installs backend deps with `npm ci --omit=dev`, so devDependencies like `@types/morgan` are not present when the predeploy hook re-runs `tsc`.

## Fix

Remove the `predeploy` build hook from `firebase.json`. The deploy job already downloads the pre-built `backend/dist` artifact produced by the `backend` CI job — recompiling in the predeploy hook is redundant and error-prone.

## Test plan
- [ ] Firebase deploy completes successfully on merge to main

https://claude.ai/code/session_01V3gq58vdyXA8v1cmRmhnEM