### PR TITLE
fix(ci): scope firebase deploy to --only hosting,functions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -131,7 +131,7 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
 
       - name: Deploy to Firebase (hosting + functions)
-        run: firebase deploy --non-interactive --project "$FIREBASE_PROJECT_ID"
+        run: firebase deploy --only hosting,functions --non-interactive --project "$FIREBASE_PROJECT_ID"
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-sa.json
           FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}


### PR DESCRIPTION
## Problem

Firebase deploy was failing with a 403 on every push:

```
Error: Request to https://serviceusage.googleapis.com/v1/projects/***/services/firestore.googleapis.com
had HTTP Error: 403, Caller does not have required permission to use project ***.
Grant the caller the roles/serviceusage.serviceUsageConsumer role...
```

Firebase CLI checks whether the Firestore API is enabled (via `serviceusage.googleapis.com`) whenever the `firestore` target is included in the deploy. The CI service account lacks the `serviceusage.services.use` permission needed for that check.

## Root cause

This is a GCP IAM issue — not fixable in code. The service account would need `roles/serviceusage.serviceUsageConsumer` added in the GCP console.

## Fix

Scope the deploy to `--only hosting,functions`. Firestore doesn't need to be deployed on every push because:
- **Rules** are static (`allow read, write: if false` — all access goes through the Admin SDK anyway)
- **Indexes** are one-time setup and rarely change

Firestore rules/indexes can be deployed manually from a local machine with appropriate credentials when they actually change.

## Test plan
- [ ] Firebase deploy step succeeds on merge to main
- [ ] Hosting and functions are updated correctly

https://claude.ai/code/session_01V3gq58vdyXA8v1cmRmhnEM