### PR TITLE
fix(ci): replace Firebase CLI functions deploy with gcloud to bypass serviceusage 403

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,6 +91,16 @@ jobs:
 
   # ──────────────────────────────────────────────
   # 3. Deploy to Firebase (main branch only)
+  #
+  # Firebase CLI calls serviceusage.googleapis.com to pre-flight every API
+  # it touches (cloudfunctions, runtimeconfig, etc.), and our service account
+  # lacks serviceusage.services.use — causing cascading 403s.
+  #
+  # Fix: bypass Firebase CLI for functions entirely.
+  # - Functions → gcloud functions deploy (calls Cloud Functions API directly,
+  #   no serviceusage pre-flight)
+  # - Hosting   → firebase deploy --only hosting (only checks
+  #   firebasehosting.googleapis.com, which IS enabled on every Firebase project)
   # ──────────────────────────────────────────────
   deploy:
     name: Deploy to Firebase
@@ -100,11 +110,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
 
       - name: Download frontend artifact
         uses: actions/download-artifact@v4
@@ -118,20 +123,45 @@ jobs:
           name: backend-dist
           path: backend/dist
 
-      - name: Install backend production deps
-        working-directory: backend
-        run: npm ci --omit=dev
+      # Sets GOOGLE_APPLICATION_CREDENTIALS and configures gcloud auth
+      # from the same service account JSON — no separate credential file step needed.
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
+      # gcloud calls cloudfunctions.googleapis.com directly — no serviceusage pre-flight.
+      # Cloud Build installs production deps from package.json after upload
+      # (node_modules is excluded by backend/.gcloudignore).
+      - name: Deploy Cloud Function
+        run: |
+          gcloud functions deploy api \
+            --project="$FIREBASE_PROJECT_ID" \
+            --runtime=nodejs20 \
+            --trigger-http \
+            --allow-unauthenticated \
+            --source=backend \
+            --entry-point=api \
+            --region=us-central1 \
+            --set-env-vars="NODE_ENV=production,CORS_ORIGINS=https://${FIREBASE_PROJECT_ID}.web.app,https://${FIREBASE_PROJECT_ID}.firebaseapp.com" \
+            --quiet
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
-      - name: Write service account credentials
-        run: echo "$FIREBASE_SERVICE_ACCOUNT" > /tmp/firebase-sa.json
+      # Only deploys hosting — checks only firebasehosting.googleapis.com (enabled).
+      # GOOGLE_APPLICATION_CREDENTIALS is already set by the auth step above.
+      - name: Deploy Firebase Hosting
+        run: firebase deploy --only hosting --non-interactive --project "$FIREBASE_PROJECT_ID"
         env:
-          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-
-      - name: Deploy to Firebase (hosting + functions)
-        run: firebase deploy --only hosting,functions --non-interactive --project "$FIREBASE_PROJECT_ID"
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-sa.json
           FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}

--- a/backend/.gcloudignore
+++ b/backend/.gcloudignore
@@ -1,0 +1,19 @@
+# What gcloud uploads for Cloud Functions deployment.
+# When this file exists, gcloud uses ONLY this list (ignores .gitignore).
+# We include dist/ (compiled JS) and package*.json; exclude everything else.
+
+.git
+.gitignore
+.gcloudignore
+.env*
+
+# TypeScript source — not needed at runtime (dist/ is already compiled)
+src/
+tsconfig.json
+
+# Dev tooling
+.eslintrc*
+*.md
+
+# Dependencies — Cloud Build installs production deps from package.json
+node_modules/

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,7 +2,7 @@
   "name": "replic-backend",
   "version": "0.1.0",
   "description": "Replic API server — Node.js + Express",
-  "main": "dist/index.js",
+  "main": "dist/functions.js",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Problem

Firebase CLI pre-flights **every API it touches** via `serviceusage.googleapis.com` before deploying. Our service account lacks `serviceusage.services.use`, producing cascading 403s:

- Run 4: `firestore.googleapis.com` → we removed Firestore from deploy
- Run 5: `runtimeconfig.googleapis.com` → same root cause, different API
- Run 6 (without this fix): would have hit the next API in the list

Patching deploy targets one at a time is whack-a-mole.

## Root cause

Firebase CLI's design: it **always** calls serviceusage to verify APIs are enabled before any deployment step. The service account would need `roles/serviceusage.serviceUsageConsumer` to satisfy these checks — a GCP IAM change that can't be made in code.

## Fix

**Functions → `gcloud functions deploy`**
- Calls `cloudfunctions.googleapis.com` directly; no serviceusage pre-flight
- Cloud Build installs production deps server-side (no need to `npm ci` in CI)
- `backend/.gcloudignore` ensures `dist/` is uploaded and `node_modules/`/`src/` are not

**Hosting → `firebase deploy --only hosting`**
- Only checks `firebasehosting.googleapis.com` — enabled on every Firebase project ✓

**Auth → `google-github-actions/auth@v2`**
- Replaces the manual `echo "$SA" > /tmp/sa.json` pattern
- Sets `GOOGLE_APPLICATION_CREDENTIALS` and configures gcloud in one step — both tools pick it up automatically

**Also fixed: `backend/package.json` `main` field**
- Was `dist/index.js` — the standalone Express server that just calls `app.listen()`
- Should be `dist/functions.js` — the Cloud Functions entry point that exports `api`
- `gcloud functions deploy --entry-point=api` uses `main` to locate the exported function; this would have been the next failure after fixing the 403

## What gcloud uploads (via `.gcloudignore`)

| Included | Excluded |
|----------|----------|
| `dist/` (compiled JS) | `src/` (TypeScript source) |
| `package.json` + `package-lock.json` | `node_modules/` (Cloud Build installs these) |
| | `.env*`, tooling config |

## Test plan
- [ ] `Deploy Cloud Function` step succeeds (no serviceusage 403)
- [ ] `Deploy Firebase Hosting` step succeeds
- [ ] Function is reachable via Firebase Hosting `/api/**` rewrite

https://claude.ai/code/session_01V3gq58vdyXA8v1cmRmhnEM