### PR TITLE
fix(ci): use gcloud custom delimiter for --set-env-vars with comma in value

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -146,7 +146,7 @@ jobs:
             --source=backend \
             --entry-point=api \
             --region=us-central1 \
-            --set-env-vars="NODE_ENV=production,CORS_ORIGINS=https://${FIREBASE_PROJECT_ID}.web.app,https://${FIREBASE_PROJECT_ID}.firebaseapp.com" \
+            --set-env-vars="^|^NODE_ENV=production|CORS_ORIGINS=https://${FIREBASE_PROJECT_ID}.web.app,https://${FIREBASE_PROJECT_ID}.firebaseapp.com" \
             --quiet
         env:
           FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}


### PR DESCRIPTION
## Problem

```
Bad syntax for dict arg: [https://***.firebaseapp.com].
```

`--set-env-vars` uses `,` as its key=value pair delimiter. `CORS_ORIGINS` contains a comma-separated list of URLs, so gcloud parsed the second URL as a separate (malformed) env var entry.

## Fix

Use gcloud's `^DELIMITER^` escape syntax to switch the delimiter from `,` to `|`:

```
--set-env-vars="^|^NODE_ENV=production|CORS_ORIGINS=https://project.web.app,https://project.firebaseapp.com"
```

The `|` between key=value pairs is now the separator; the `,` inside `CORS_ORIGINS` is treated as a literal value character.

Reference: `gcloud topic escaping`

https://claude.ai/code/session_01V3gq58vdyXA8v1cmRmhnEM