### PR TITLE
fix: set Node.js engine to 20 for Firebase Functions compatibility

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "Replic API server — Node.js + Express",
   "main": "dist/functions.js",
   "engines": {
-    "node": ">=18"
+    "node": "20"
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",


### PR DESCRIPTION
Firebase Functions only supports specific Node.js versions (20, 22, 24). The previous `>=18` range is rejected at deploy time.

https://claude.ai/code/session_01V3gq58vdyXA8v1cmRmhnEM