### PR TITLE
fix: add --force to firebase deploy to suppress cleanup policy error

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -132,7 +132,7 @@ jobs:
         run: npm install -g firebase-tools
 
       - name: Deploy to Firebase
-        run: firebase deploy --only hosting,functions --non-interactive --project "$FIREBASE_PROJECT_ID"
+        run: firebase deploy --only hosting,functions --non-interactive --force --project "$FIREBASE_PROJECT_ID"
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}


### PR DESCRIPTION
Functions and hosting deployed successfully, but Firebase CLI exited with code 1 because it couldn't auto-create an Artifact Registry cleanup policy. --force allows it to set that up automatically.

https://claude.ai/code/session_01V3gq58vdyXA8v1cmRmhnEM