### PR TITLE
Add Firebase configuration file to version control

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "replic-1"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ Thumbs.db
 firebase-debug.log
 firestore-debug.log
 ui-debug.log
-.firebaserc
 
 # TypeScript
 *.tsbuildinfo


### PR DESCRIPTION
## Summary
This change adds the `.firebaserc` configuration file to version control and removes it from the `.gitignore` file, allowing the Firebase project configuration to be shared across the team.

## Key Changes
- Added `.firebaserc` file with the default Firebase project set to `replic-1`
- Removed `.firebaserc` from `.gitignore` to allow the file to be tracked in git

## Details
The `.firebaserc` file contains the Firebase project configuration and is now committed to the repository. This enables team members to have a consistent Firebase project reference without requiring manual setup. The file specifies `replic-1` as the default Firebase project for this codebase.

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15