### PR TITLE
Fix Firebase Functions deployment (issues #8 and #11)

### DIFF
--- a/backend/.env.replic-1
+++ b/backend/.env.replic-1
@@ -1,0 +1,5 @@
+# Firebase Functions environment — loaded automatically for project replic-1
+# https://firebase.google.com/docs/functions/config-env#env-variables
+
+CORS_ORIGINS=https://replic-1.web.app,https://replic-1.firebaseapp.com
+NODE_ENV=production

--- a/firebase.json
+++ b/firebase.json
@@ -42,7 +42,7 @@
         "firebase-debug.log",
         "firebase-debug.*.log"
       ],
-      "predeploy": []
+      "predeploy": ["npm --prefix backend run build"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **#8 — `.firebaserc`**: creates the file linking the repo to Firebase project `replic-1`, and removes it from `.gitignore` so it can be tracked
- **#11 — Firebase Functions deployment**: two changes required for a working deploy:
  - `firebase.json`: populate the empty `predeploy` array with `npm --prefix backend run build` so TypeScript is compiled before upload
  - `backend/.env.replic-1`: project-scoped env file (loaded automatically by Firebase CLI) that sets `CORS_ORIGINS` to the two Firebase Hosting domains — without this the deployed API defaults to `localhost:5173` and rejects production frontend requests

## Test plan

- [ ] `firebase deploy --only functions` compiles TypeScript before uploading
- [ ] Deployed API responds to requests from `https://replic-1.web.app` and `https://replic-1.firebaseapp.com`
- [ ] `GET /api/health` returns `{"status":"ok"}` from the deployed function URL

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15