### PR TITLE
fix(ci): install devDeps in deploy job so predeploy tsc succeeds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -119,9 +119,9 @@ jobs:
           name: backend-dist
           path: backend/dist
 
-      - name: Install backend production deps
+      - name: Install backend deps
         working-directory: backend
-        run: npm ci --omit=dev
+        run: npm ci
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

The deploy job ran `npm ci --omit=dev`, skipping devDependencies like `@types/morgan`. Firebase CLI then triggered the `predeploy` build step (`tsc`), which failed because the type declarations were missing.

## Fix

Change `npm ci --omit=dev` → `npm ci` in the deploy job. devDependencies are not included in what Firebase uploads to Cloud Functions — the Firebase servers run their own `npm install --production` on the uploaded source — so this only affects the local build step, not the deployed bundle.

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15