### PR TITLE
fix(designs): resolve POST /api/designs 500 and response shape mismatches (issue #41)

### DIFF
--- a/backend/src/lib/firebase.ts
+++ b/backend/src/lib/firebase.ts
@@ -17,3 +17,4 @@ if (!admin.apps.length) {
 
 export const adminAuth = admin.auth()
 export const adminDb = admin.firestore()
+adminDb.settings({ ignoreUndefinedProperties: true })

--- a/frontend/src/pages/CreateDesign.tsx
+++ b/frontend/src/pages/CreateDesign.tsx
@@ -16,8 +16,8 @@ export default function CreateDesign() {
     setError('')
     try {
       const body = formValuesToBody(values)
-      const created = await api.post<Design>('/api/designs', body)
-      navigate(`/designs/${created.id}`)
+      const res = await api.post<{ status: string; data: Design }>('/api/designs', body)
+      navigate(`/designs/${res.data.id}`)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create design')
     } finally {

--- a/frontend/src/pages/EditDesign.tsx
+++ b/frontend/src/pages/EditDesign.tsx
@@ -39,8 +39,8 @@ export default function EditDesign() {
   const [error, setError] = useState('')
 
   useEffect(() => {
-    api.get<Design>(`/api/designs/${id}`)
-      .then((d) => {
+    api.get<{ status: string; data: Design }>(`/api/designs/${id}`)
+      .then(({ data: d }) => {
         setDesign(d)
         setValues(designToFormValues(d))
       })


### PR DESCRIPTION
Fixes #41

## Root causes

### 1. Backend 500 — Firestore rejects `undefined` field values

Firebase Admin SDK v10+ throws when a document being written contains `undefined` values (`"Cannot use 'undefined' as a Firestore value"`). All optional fields on the design (`sample_size`, `repetitions`, `analysis_plan`, `estimated_duration`, etc.) are `undefined` when the user doesn't fill them in, causing `docRef.set(design)` to throw and surface as a 500.

**Fix:** `adminDb.settings({ ignoreUndefinedProperties: true })` in `firebase.ts` — Firestore silently drops `undefined` fields instead of throwing.

### 2. `CreateDesign.tsx` — wrong response shape after POST

`api.post<Design>(...)` but the backend returns `{ status, data: Design }`. Even after fixing the 500, navigation would have gone to `/designs/undefined` because `created.id` was being read from the wrapper object.

**Fix:** type as `{ status: string; data: Design }` and navigate using `res.data.id`.

### 3. `EditDesign.tsx` — same mismatch on initial GET

The form loaded with all blank fields because `d.title`, `d.hypothesis`, etc. were being read from the response wrapper instead of `d.data`.

**Fix:** destructure `{ data: d }` from the response.

## Test plan
- [ ] Fill out and submit the New Design form → design is created and user is redirected to the detail page
- [ ] Open an existing design's edit page → all fields are pre-populated correctly
- [ ] Submit the edit form → changes are saved and user is redirected to the detail page
- [ ] Verify optional fields (sample size, analysis plan, etc.) can be left blank without causing errors

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15