### PR TITLE
feat(materials): Materials browse page and detail view (issue #43)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import MyDesigns from './pages/MyDesigns'
 import CreateDesign from './pages/CreateDesign'
 import EditDesign from './pages/EditDesign'
 import DesignDetail from './pages/DesignDetail'
+import Materials from './pages/Materials'
+import MaterialDetail from './pages/MaterialDetail'
 
 export default function App() {
   return (
@@ -18,6 +20,8 @@ export default function App() {
         <Route index element={<Home />} />
         <Route path="experiments" element={<Experiments />} />
         <Route path="designs/:id" element={<DesignDetail />} />
+        <Route path="materials" element={<Materials />} />
+        <Route path="materials/:id" element={<MaterialDetail />} />
 
         {/* Protected */}
         <Route element={<PrivateRoute />}>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext'
 const publicNavLinks = [
   { to: '/', label: 'Home', end: true },
   { to: '/experiments', label: 'Experiments', end: false },
+  { to: '/materials', label: 'Materials', end: false },
 ]
 
 export default function Navbar() {

--- a/frontend/src/pages/MaterialDetail.tsx
+++ b/frontend/src/pages/MaterialDetail.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { api } from '../lib/api'
+import type { Material } from '../types/material'
+
+export default function MaterialDetail() {
+  const { id } = useParams<{ id: string }>()
+  const [material, setMaterial] = useState<Material | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    api.get<{ status: string; data: Material }>(`/api/materials/${id}`)
+      .then(({ data }) => setMaterial(data))
+      .catch((err: any) => {
+        if (err?.status === 404) setNotFound(true)
+        else setError(err?.message ?? 'Failed to load')
+      })
+      .finally(() => setLoading(false))
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="w-8 h-8 border-4 border-brand-600 border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (notFound || !material) {
+    return (
+      <div className="max-w-2xl mx-auto py-20 px-4 text-center">
+        <p className="text-4xl mb-4">🔍</p>
+        <h1 className="text-xl font-semibold text-gray-900">Material not found</h1>
+        <p className="mt-2 text-sm text-gray-500">It may have been removed or the link may be incorrect.</p>
+        <Link to="/materials" className="mt-4 inline-block btn-secondary text-sm">Browse materials</Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              <span className="text-xs bg-brand-50 text-brand-700 px-2 py-0.5 rounded-full capitalize">
+                {material.type}
+              </span>
+              <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full capitalize">
+                {material.category}
+              </span>
+              {material.is_verified && (
+                <span className="text-xs bg-green-50 text-green-700 px-2 py-0.5 rounded-full">
+                  Verified
+                </span>
+              )}
+            </div>
+            <h1 className="text-2xl font-bold text-gray-900">{material.name}</h1>
+          </div>
+        </div>
+      </div>
+
+      {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+
+      {/* Description */}
+      {material.description && (
+        <section className="card p-5 mb-4">
+          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">Description</h2>
+          <p className="text-gray-800">{material.description}</p>
+        </section>
+      )}
+
+      {/* Details */}
+      <section className="card p-5 mb-4">
+        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Details</h2>
+        <dl className="space-y-2 text-sm">
+          <div className="flex gap-2">
+            <dt className="w-32 shrink-0 text-gray-500">Unit</dt>
+            <dd className="text-gray-800">{material.unit}</dd>
+          </div>
+          {material.supplier && (
+            <div className="flex gap-2">
+              <dt className="w-32 shrink-0 text-gray-500">Supplier</dt>
+              <dd className="text-gray-800">{material.supplier}</dd>
+            </div>
+          )}
+          {material.typical_cost_usd != null && (
+            <div className="flex gap-2">
+              <dt className="w-32 shrink-0 text-gray-500">Typical cost</dt>
+              <dd className="text-gray-800">${material.typical_cost_usd.toFixed(2)}</dd>
+            </div>
+          )}
+          {material.link && (
+            <div className="flex gap-2">
+              <dt className="w-32 shrink-0 text-gray-500">Product link</dt>
+              <dd>
+                <a
+                  href={material.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-brand-600 hover:underline break-all"
+                >
+                  {material.link}
+                </a>
+              </dd>
+            </div>
+          )}
+        </dl>
+      </section>
+
+      {/* Safety notes */}
+      {material.safety_notes && (
+        <section className="card p-5 mb-4">
+          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">Safety Notes</h2>
+          <p className="text-gray-800 text-sm whitespace-pre-line">{material.safety_notes}</p>
+        </section>
+      )}
+
+      {/* Tags */}
+      {material.tags.length > 0 && (
+        <section className="card p-5 mb-4">
+          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Tags</h2>
+          <div className="flex flex-wrap gap-1.5">
+            {material.tags.map((tag) => (
+              <span key={tag} className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
+                {tag}
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <Link to="/materials" className="text-sm text-brand-600 hover:underline">
+        ← Back to materials
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/pages/Materials.tsx
+++ b/frontend/src/pages/Materials.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { api } from '../lib/api'
+import type { Material, MaterialCategory, MaterialListResponse } from '../types/material'
+
+const CATEGORY_OPTIONS: { value: MaterialCategory; label: string }[] = [
+  { value: 'glassware', label: 'Glassware' },
+  { value: 'reagent', label: 'Reagent' },
+  { value: 'equipment', label: 'Equipment' },
+  { value: 'biological', label: 'Biological' },
+  { value: 'other', label: 'Other' },
+]
+
+export default function Materials() {
+  const [materials, setMaterials] = useState<Material[]>([])
+  const [cursor, setCursor] = useState<string | undefined>()
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [category, setCategory] = useState('')
+
+  function buildQuery(after?: string) {
+    const params = new URLSearchParams()
+    if (category) params.set('category', category)
+    if (after) params.set('after', after)
+    const qs = params.toString()
+    return `/api/materials${qs ? `?${qs}` : ''}`
+  }
+
+  async function fetchMaterials() {
+    setLoading(true)
+    try {
+      const res = await api.get<MaterialListResponse>(buildQuery())
+      setMaterials(res.data)
+      setCursor(res.data.length === 20 ? res.data[res.data.length - 1]?.id : undefined)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function loadMore() {
+    if (!cursor) return
+    setLoadingMore(true)
+    try {
+      const res = await api.get<MaterialListResponse>(buildQuery(cursor))
+      setMaterials((prev) => [...prev, ...res.data])
+      setCursor(res.data.length === 20 ? res.data[res.data.length - 1]?.id : undefined)
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchMaterials()
+  }, [category])
+
+  return (
+    <div className="max-w-4xl mx-auto py-8 px-4">
+      <div className="mb-6">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Materials</h1>
+        <p className="mt-2 text-gray-600">Browse the catalog of consumables and equipment used in experiment designs.</p>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 mb-6">
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+        >
+          <option value="">All categories</option>
+          {CATEGORY_OPTIONS.map(({ value, label }) => (
+            <option key={value} value={value}>{label}</option>
+          ))}
+        </select>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-20">
+          <div className="w-8 h-8 border-4 border-brand-600 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : materials.length === 0 ? (
+        <div className="card p-12 flex flex-col items-center text-center">
+          <div className="text-5xl mb-4">🧪</div>
+          <h2 className="text-lg font-semibold text-gray-900">No materials found</h2>
+          <p className="mt-2 text-sm text-gray-500 max-w-sm">
+            Try adjusting your filters or check back soon.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-3">
+            {materials.map((material) => (
+              <MaterialCard key={material.id} material={material} />
+            ))}
+          </div>
+
+          {cursor && (
+            <div className="mt-6 text-center">
+              <button
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="btn-secondary text-sm disabled:opacity-50"
+              >
+                {loadingMore ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function MaterialCard({ material }: { material: Material }) {
+  return (
+    <Link
+      to={`/materials/${material.id}`}
+      className="block card p-5 hover:shadow-md transition-shadow"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-semibold text-gray-900">{material.name}</h3>
+            {material.is_verified && (
+              <span className="text-xs font-medium bg-green-50 text-green-700 px-2 py-0.5 rounded-full">
+                Verified
+              </span>
+            )}
+          </div>
+          {material.description && (
+            <p className="mt-1 text-sm text-gray-600 line-clamp-2">{material.description}</p>
+          )}
+        </div>
+        <span className="shrink-0 text-xs font-medium bg-brand-50 text-brand-700 px-2 py-0.5 rounded-full capitalize">
+          {material.type}
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-gray-500">
+        <span className="capitalize">{material.category}</span>
+        <span>·</span>
+        <span>{material.unit}</span>
+        {material.typical_cost_usd != null && (
+          <>
+            <span>·</span>
+            <span>${material.typical_cost_usd.toFixed(2)}</span>
+          </>
+        )}
+        {material.supplier && (
+          <>
+            <span>·</span>
+            <span>{material.supplier}</span>
+          </>
+        )}
+      </div>
+
+      {material.tags.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {material.tags.map((tag) => (
+            <span key={tag} className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </Link>
+  )
+}

--- a/frontend/src/types/material.ts
+++ b/frontend/src/types/material.ts
@@ -1,0 +1,27 @@
+export type MaterialType = 'Consumable' | 'Equipment'
+
+export type MaterialCategory = 'glassware' | 'reagent' | 'equipment' | 'biological' | 'other'
+
+export interface Material {
+  id: string
+  name: string
+  type: MaterialType
+  description?: string
+  category: MaterialCategory
+  link?: string
+  supplier?: string
+  unit: string
+  typical_cost_usd?: number
+  safety_notes?: string
+  tags: string[]
+  is_verified: boolean
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+export interface MaterialListResponse {
+  status: string
+  data: Material[]
+  count: number
+}


### PR DESCRIPTION
Fixes #43

## Summary

- **`frontend/src/types/material.ts`** — `Material`, `MaterialListResponse`, `MaterialType`, `MaterialCategory` types mirroring the backend schema
- **`frontend/src/pages/Materials.tsx`** — public `/materials` browse page: category filter dropdown, card list, Load More pagination, loading spinner, empty state
- **`frontend/src/pages/MaterialDetail.tsx`** — `/materials/:id` detail page: full field display (description, details table, safety notes, tags), 404 state
- **`frontend/src/App.tsx`** — registers `/materials` and `/materials/:id` as public routes
- **`frontend/src/components/Navbar.tsx`** — Materials link added to `publicNavLinks`

Follows the same patterns as `Experiments.tsx` / `DesignDetail.tsx` throughout.

## Test plan
- [ ] `/materials` loads and shows all materials
- [ ] Category filter narrows the list and resets pagination
- [ ] Load More appends next page
- [ ] Empty state shown when no results match
- [ ] Each card links to `/materials/:id`
- [ ] Detail page shows all populated fields
- [ ] Detail page shows 404 state for unknown ID
- [ ] Verified badge renders on verified materials
- [ ] Materials link appears in the nav (desktop + mobile)

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15