### PR TITLE
feat(materials): Submit a Material form (issue #44)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import EditDesign from './pages/EditDesign'
 import DesignDetail from './pages/DesignDetail'
 import Materials from './pages/Materials'
 import MaterialDetail from './pages/MaterialDetail'
+import CreateMaterial from './pages/CreateMaterial'
 
 export default function App() {
   return (
@@ -29,6 +30,7 @@ export default function App() {
           <Route path="designs/mine" element={<MyDesigns />} />
           <Route path="designs/new" element={<CreateDesign />} />
           <Route path="designs/:id/edit" element={<EditDesign />} />
+          <Route path="materials/new" element={<CreateMaterial />} />
         </Route>
 
         <Route path="*" element={<NotFound />} />

--- a/frontend/src/components/MaterialForm.tsx
+++ b/frontend/src/components/MaterialForm.tsx
@@ -1,0 +1,185 @@
+import type { MaterialCategory, MaterialType } from '../types/material'
+
+const CATEGORY_OPTIONS: { value: MaterialCategory; label: string }[] = [
+  { value: 'glassware', label: 'Glassware' },
+  { value: 'reagent', label: 'Reagent' },
+  { value: 'equipment', label: 'Equipment' },
+  { value: 'biological', label: 'Biological' },
+  { value: 'other', label: 'Other' },
+]
+
+export interface MaterialFormValues {
+  name: string
+  type: MaterialType | ''
+  category: MaterialCategory | ''
+  unit: string
+  description: string
+  supplier: string
+  typical_cost_usd: string  // string for controlled input
+  safety_notes: string
+  tags: string              // comma-separated
+}
+
+export function defaultMaterialFormValues(): MaterialFormValues {
+  return {
+    name: '',
+    type: '',
+    category: '',
+    unit: '',
+    description: '',
+    supplier: '',
+    typical_cost_usd: '',
+    safety_notes: '',
+    tags: '',
+  }
+}
+
+export function formValuesToBody(v: MaterialFormValues) {
+  return {
+    name: v.name,
+    type: v.type as MaterialType,
+    category: v.category as MaterialCategory,
+    ...(v.unit ? { unit: v.unit } : {}),
+    ...(v.description ? { description: v.description } : {}),
+    ...(v.supplier ? { supplier: v.supplier } : {}),
+    ...(v.typical_cost_usd ? { typical_cost_usd: parseFloat(v.typical_cost_usd) } : {}),
+    ...(v.safety_notes ? { safety_notes: v.safety_notes } : {}),
+    tags: v.tags.split(',').map((t) => t.trim()).filter(Boolean),
+  }
+}
+
+interface Props {
+  values: MaterialFormValues
+  onChange: (v: MaterialFormValues) => void
+}
+
+export default function MaterialForm({ values, onChange }: Props) {
+  function set<K extends keyof MaterialFormValues>(key: K, val: MaterialFormValues[K]) {
+    onChange({ ...values, [key]: val })
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Name */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+        <input
+          type="text"
+          required
+          maxLength={200}
+          value={values.name}
+          onChange={(e) => set('name', e.target.value)}
+          placeholder="e.g. Erlenmeyer Flask (250 mL)"
+          className="w-full input-sm"
+        />
+      </div>
+
+      {/* Type + Category */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Type *</label>
+          <select
+            required
+            value={values.type}
+            onChange={(e) => set('type', e.target.value as MaterialType | '')}
+            className="w-full input-sm"
+          >
+            <option value="">Select type…</option>
+            <option value="Consumable">Consumable</option>
+            <option value="Equipment">Equipment</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Category *</label>
+          <select
+            required
+            value={values.category}
+            onChange={(e) => set('category', e.target.value as MaterialCategory | '')}
+            className="w-full input-sm"
+          >
+            <option value="">Select category…</option>
+            {CATEGORY_OPTIONS.map(({ value, label }) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Unit + Supplier */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Unit <span className="text-gray-400 font-normal">(default: unit)</span>
+          </label>
+          <input
+            type="text"
+            value={values.unit}
+            onChange={(e) => set('unit', e.target.value)}
+            placeholder="unit, mL, g, …"
+            className="w-full input-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Supplier</label>
+          <input
+            type="text"
+            value={values.supplier}
+            onChange={(e) => set('supplier', e.target.value)}
+            placeholder="e.g. Fisher Scientific"
+            className="w-full input-sm"
+          />
+        </div>
+      </div>
+
+      {/* Description */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+        <textarea
+          rows={3}
+          value={values.description}
+          onChange={(e) => set('description', e.target.value)}
+          className="w-full input-sm resize-y"
+        />
+      </div>
+
+      {/* Typical cost */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Typical cost (USD)</label>
+        <input
+          type="number"
+          min={0}
+          step="0.01"
+          value={values.typical_cost_usd}
+          onChange={(e) => set('typical_cost_usd', e.target.value)}
+          placeholder="0.00"
+          className="w-full input-sm"
+        />
+      </div>
+
+      {/* Safety notes */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Safety notes</label>
+        <textarea
+          rows={2}
+          value={values.safety_notes}
+          onChange={(e) => set('safety_notes', e.target.value)}
+          className="w-full input-sm resize-y"
+        />
+      </div>
+
+      {/* Tags */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Tags <span className="text-gray-400 font-normal">(comma-separated, max 10)</span>
+        </label>
+        <input
+          type="text"
+          value={values.tags}
+          onChange={(e) => set('tags', e.target.value)}
+          placeholder="chemistry, lab, glassware"
+          className="w-full input-sm"
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/CreateMaterial.tsx
+++ b/frontend/src/pages/CreateMaterial.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api } from '../lib/api'
+import type { Material } from '../types/material'
+import MaterialForm, { defaultMaterialFormValues, formValuesToBody, type MaterialFormValues } from '../components/MaterialForm'
+
+export default function CreateMaterial() {
+  const navigate = useNavigate()
+  const [values, setValues] = useState<MaterialFormValues>(defaultMaterialFormValues())
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError('')
+    try {
+      const res = await api.post<{ status: string; data: Material }>('/api/materials', formValuesToBody(values))
+      navigate(`/materials/${res.data.id}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit material')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Submit a Material</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <MaterialForm values={values} onChange={setValues} />
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        <div className="flex gap-3 pt-2">
+          <button type="submit" disabled={submitting} className="btn-primary text-sm disabled:opacity-50">
+            {submitting ? 'Submitting…' : 'Submit material'}
+          </button>
+          <button type="button" onClick={() => navigate('/materials')} className="btn-secondary text-sm">
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/Materials.tsx
+++ b/frontend/src/pages/Materials.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
 import type { Material, MaterialCategory, MaterialListResponse } from '../types/material'
 
 const CATEGORY_OPTIONS: { value: MaterialCategory; label: string }[] = [
@@ -12,6 +13,7 @@ const CATEGORY_OPTIONS: { value: MaterialCategory; label: string }[] = [
 ]
 
 export default function Materials() {
+  const { user } = useAuth()
   const [materials, setMaterials] = useState<Material[]>([])
   const [cursor, setCursor] = useState<string | undefined>()
   const [loading, setLoading] = useState(true)
@@ -55,9 +57,16 @@ export default function Materials() {
 
   return (
     <div className="max-w-4xl mx-auto py-8 px-4">
-      <div className="mb-6">
-        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Materials</h1>
-        <p className="mt-2 text-gray-600">Browse the catalog of consumables and equipment used in experiment designs.</p>
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Materials</h1>
+          <p className="mt-2 text-gray-600">Browse the catalog of consumables and equipment used in experiment designs.</p>
+        </div>
+        {user && (
+          <Link to="/materials/new" className="btn-primary text-sm shrink-0">
+            Submit material
+          </Link>
+        )}
       </div>
 
       {/* Filters */}


### PR DESCRIPTION
Fixes #44

## Summary

- **`MaterialForm.tsx`** — reusable controlled form component (mirrors `DesignForm` pattern) with all fields from the spec plus `type` (required by the API)
- **`CreateMaterial.tsx`** — `/materials/new` page; on success redirects to the new material's detail page
- **`App.tsx`** — `materials/new` added as a protected route inside the existing `PrivateRoute` block (static segment takes precedence over `materials/:id`)
- **`Materials.tsx`** — "Submit material" CTA button in page header, auth-gated via `useAuth`

## Test plan
- [ ] Signed-in user sees "Submit material" button on `/materials`
- [ ] Signed-out user does not see the button
- [ ] Navigating to `/materials/new` when signed out redirects to sign-in
- [ ] Submitting the form with required fields creates the material and redirects to its detail page
- [ ] Missing required fields (name, type, category) surface a validation error
- [ ] Tags are parsed correctly from comma-separated input
- [ ] Cancel returns to `/materials`

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15