### PR TITLE
Materials feature + design system + 3 UI explorations

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "replic-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "daisyui": "^3.9.4",
         "firebase": "^12.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -33,7 +34,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1527,7 +1527,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1549,7 +1548,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1559,14 +1557,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1577,7 +1573,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1591,7 +1586,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1601,7 +1595,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2438,14 +2431,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2459,7 +2450,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -2540,7 +2530,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2563,7 +2552,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2620,7 +2608,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2668,7 +2655,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2693,7 +2679,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2734,11 +2719,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2773,11 +2763,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-selector-tokenizer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
+      "integrity": "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "fastparse": "^1.1.2"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -2792,6 +2791,26 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/daisyui": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-3.9.4.tgz",
+      "integrity": "sha512-fvi2RGH4YV617/6DntOVGcOugOPym9jTGWW2XySb5ZpvdWO4L7bEG77VHirrnbRUEWvIEVXkBpxUz2KFj0rVnA==",
+      "license": "MIT",
+      "dependencies": {
+        "colord": "^2.9",
+        "css-selector-tokenizer": "^0.8",
+        "postcss": "^8",
+        "postcss-js": "^4",
+        "tailwindcss": "^3.1"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/daisyui"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2822,7 +2841,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dir-glob": {
@@ -2842,7 +2860,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -3141,7 +3158,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3158,7 +3174,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3181,11 +3196,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fastparse": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3220,7 +3240,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3353,7 +3372,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3368,7 +3386,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3419,7 +3436,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -3510,7 +3526,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3591,7 +3606,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -3604,7 +3618,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -3620,7 +3633,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3639,7 +3651,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3652,7 +3663,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3679,7 +3689,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -3779,7 +3788,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -3792,7 +3800,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -3856,7 +3863,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3866,7 +3872,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -3903,7 +3908,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -3915,7 +3919,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3948,7 +3951,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3958,7 +3960,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3968,7 +3969,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4081,7 +4081,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -4098,14 +4097,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4118,7 +4115,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4128,7 +4124,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4138,7 +4133,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4167,7 +4161,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -4185,7 +4178,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4211,7 +4203,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4254,7 +4245,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4280,7 +4270,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -4294,7 +4283,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -4345,7 +4333,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4433,7 +4420,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -4443,7 +4429,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -4465,7 +4450,6 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -4496,7 +4480,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -4569,7 +4552,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4668,7 +4650,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4717,7 +4698,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -4753,7 +4733,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4766,7 +4745,6 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -4811,7 +4789,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -4821,7 +4798,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -4834,7 +4810,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4851,7 +4826,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -4869,7 +4843,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4882,7 +4855,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -4908,7 +4880,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -5008,7 +4979,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "daisyui": "^3.9.4",
     "firebase": "^12.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,9 @@ import CreateDesign from './pages/CreateDesign'
 import EditDesign from './pages/EditDesign'
 import DesignDetail from './pages/DesignDetail'
 import Materials from './pages/Materials'
+import Materials1 from './pages/Materials1'
+import Materials2 from './pages/Materials2'
+import Materials3 from './pages/Materials3'
 import MaterialDetail from './pages/MaterialDetail'
 import CreateMaterial from './pages/CreateMaterial'
 
@@ -22,6 +25,9 @@ export default function App() {
         <Route path="experiments" element={<Experiments />} />
         <Route path="designs/:id" element={<DesignDetail />} />
         <Route path="materials" element={<Materials />} />
+        <Route path="materials-1" element={<Materials1 />} />
+        <Route path="materials-2" element={<Materials2 />} />
+        <Route path="materials-3" element={<Materials3 />} />
         <Route path="materials/:id" element={<MaterialDetail />} />
 
         {/* Protected */}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -5,11 +5,18 @@ import { useAuth } from '../contexts/AuthContext'
 const publicNavLinks = [
   { to: '/', label: 'Home', end: true },
   { to: '/experiments', label: 'Experiments', end: false },
-  { to: '/materials', label: 'Materials', end: false },
+  { to: '/materials', label: 'Materials', end: true },
+]
+
+const previewNavLinks = [
+  { to: '/materials-1', label: 'Materials 1', end: false },
+  { to: '/materials-2', label: 'Materials 2', end: false },
+  { to: '/materials-3', label: 'Materials 3', end: false },
 ]
 
 export default function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [previewOpen, setPreviewOpen] = useState(false)
   const { user, loading, signIn, signOut } = useAuth()
 
   const navLinks = [
@@ -55,7 +62,12 @@ export default function Navbar() {
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <Link to="/" className="flex items-center gap-2">
-            <span className="text-xl font-bold text-brand-600 tracking-tight">Replic</span>
+            <span
+              className="text-xl font-bold tracking-tight"
+              style={{ color: 'var(--color-primary)', fontFamily: 'var(--font-display)' }}
+            >
+              Replic
+            </span>
             <span className="hidden sm:inline-block text-xs font-medium text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">
               alpha
             </span>
@@ -71,7 +83,7 @@ export default function Navbar() {
                 className={({ isActive }) =>
                   `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                     isActive
-                      ? 'bg-brand-50 text-brand-700'
+                      ? 'bg-surface text-primary'
                       : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
                   }`
                 }
@@ -79,6 +91,45 @@ export default function Navbar() {
                 {label}
               </NavLink>
             ))}
+
+            {/* Preview dropdown */}
+            <div className="relative">
+              <button
+                onClick={() => setPreviewOpen(v => !v)}
+                onBlur={() => setTimeout(() => setPreviewOpen(false), 150)}
+                className="flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium
+                           text-gray-400 hover:bg-gray-100 hover:text-gray-700 transition-colors"
+              >
+                Preview
+                <svg
+                  className={`w-3.5 h-3.5 transition-transform ${previewOpen ? 'rotate-180' : ''}`}
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {previewOpen && (
+                <div className="absolute left-0 top-full mt-1 w-44 bg-white rounded-xl shadow-lg
+                                border border-gray-200 py-1 z-50">
+                  {previewNavLinks.map(({ to, label }) => (
+                    <NavLink
+                      key={to}
+                      to={to}
+                      onClick={() => setPreviewOpen(false)}
+                      className={({ isActive }) =>
+                        `block px-4 py-2 text-sm transition-colors ${
+                          isActive
+                            ? 'bg-surface text-primary font-medium'
+                            : 'text-gray-700 hover:bg-gray-50'
+                        }`
+                      }
+                    >
+                      {label}
+                    </NavLink>
+                  ))}
+                </div>
+              )}
+            </div>
           </nav>
 
           {/* Desktop CTA */}
@@ -116,7 +167,7 @@ export default function Navbar() {
                 className={({ isActive }) =>
                   `block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                     isActive
-                      ? 'bg-brand-50 text-brand-700'
+                      ? 'bg-surface text-primary'
                       : 'text-gray-600 hover:bg-gray-100'
                   }`
                 }
@@ -124,6 +175,27 @@ export default function Navbar() {
                 {label}
               </NavLink>
             ))}
+            <div className="pt-1 border-t border-gray-100">
+              <p className="px-3 py-1 text-xs font-medium text-gray-400 uppercase tracking-wide">
+                Preview
+              </p>
+              {previewNavLinks.map(({ to, label }) => (
+                <NavLink
+                  key={to}
+                  to={to}
+                  onClick={() => setMobileOpen(false)}
+                  className={({ isActive }) =>
+                    `block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                      isActive
+                        ? 'bg-surface text-primary'
+                        : 'text-gray-500 hover:bg-gray-100'
+                    }`
+                  }
+                >
+                  {label}
+                </NavLink>
+              ))}
+            </div>
             <div className="pt-2 flex flex-col gap-2">
               {mobileAuthButtons}
             </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,26 @@
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&family=Plus+Jakarta+Sans:wght@400;500;600&family=DM+Mono:wght@400&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --color-primary:    #C1502D;
+    --color-dark:       #2F1847;
+    --color-secondary:  #624763;
+    --color-accent:     #EABFCB;
+    --color-surface:    #F5EAE0;
+    --color-text:       #1A1025;
+    --color-text-muted: #8C7D8E;
+
+    --font-display: 'Fraunces', Georgia, serif;
+    --font-body:    'Plus Jakarta Sans', system-ui, sans-serif;
+    --font-mono:    'DM Mono', 'Courier New', monospace;
+  }
+
   html {
-    font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+    font-family: var(--font-body);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -15,23 +31,31 @@
 }
 
 @layer components {
+  /* ── Buttons ────────────────────────────────────────── */
   .btn-primary {
-    @apply inline-flex items-center px-4 py-2 bg-brand-600 text-white text-sm font-medium rounded-lg
-           hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2
-           transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply inline-flex items-center gap-1.5 px-4 py-2 bg-primary text-white
+           text-sm font-medium rounded-lg
+           hover:opacity-90 active:opacity-80
+           focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2
+           transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
   .btn-secondary {
-    @apply inline-flex items-center px-4 py-2 bg-white text-gray-700 text-sm font-medium rounded-lg
-           border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500
-           focus:ring-offset-2 transition-colors duration-150;
+    @apply inline-flex items-center gap-1.5 px-4 py-2 bg-white text-ink text-sm
+           font-medium rounded-lg border border-surface-2
+           hover:bg-surface focus:outline-none focus:ring-2 focus:ring-primary
+           focus:ring-offset-2 transition-all duration-150;
   }
 
+  /* ── Cards ──────────────────────────────────────────── */
   .card {
-    @apply bg-white rounded-xl border border-gray-200 shadow-sm;
+    @apply bg-white rounded-xl border border-surface-2 shadow-sm;
   }
 
+  /* ── Inputs ─────────────────────────────────────────── */
   .input-sm {
-    @apply border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:bg-gray-50 disabled:text-gray-500;
+    @apply border border-surface-2 rounded-lg px-3 py-2 text-sm bg-white
+           focus:outline-none focus:ring-2 focus:ring-primary
+           disabled:bg-surface disabled:text-muted;
   }
 }

--- a/frontend/src/pages/Materials1.tsx
+++ b/frontend/src/pages/Materials1.tsx
@@ -1,0 +1,263 @@
+/**
+ * Materials — Option 1: "Specimen Cabinet"
+ *
+ * Warm, editorial, side-by-side split between Equipment and Consumables.
+ * Clean information hierarchy. Distinct but not loud.
+ */
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { api } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
+import type { Material, MaterialCategory, MaterialListResponse } from '../types/material'
+import BulkUploadMaterialsModal from '../components/BulkUploadMaterialsModal'
+
+const CATEGORIES: { value: MaterialCategory; label: string }[] = [
+  { value: 'glassware',  label: 'Glassware' },
+  { value: 'reagent',    label: 'Reagent' },
+  { value: 'equipment',  label: 'Equipment' },
+  { value: 'biological', label: 'Biological' },
+  { value: 'other',      label: 'Other' },
+]
+
+const CATEGORY_COLORS: Record<MaterialCategory, string> = {
+  glassware:  'bg-blue-50 text-blue-700',
+  reagent:    'bg-amber-50 text-amber-700',
+  equipment:  'bg-emerald-50 text-emerald-700',
+  biological: 'bg-violet-50 text-violet-700',
+  other:      'bg-gray-100 text-gray-600',
+}
+
+export default function Materials1() {
+  const { user } = useAuth()
+  const [all, setAll] = useState<Material[]>([])
+  const [loading, setLoading] = useState(true)
+  const [category, setCategory] = useState<string>('')
+  const [showBulk, setShowBulk] = useState(false)
+
+  async function fetch() {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams()
+      if (category) params.set('category', category)
+      const qs = params.toString()
+      const res = await api.get<MaterialListResponse>(`/api/materials${qs ? `?${qs}` : ''}`)
+      setAll(res.data)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetch() }, [category])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  const equipment   = all.filter(m => m.type === 'Equipment')
+  const consumables = all.filter(m => m.type === 'Consumable')
+
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--color-surface)' }}>
+      {/* ── Page header ── */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-6">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="text-xs font-mono tracking-widest text-muted uppercase mb-1">
+              Catalog
+            </p>
+            <h1
+              className="text-4xl sm:text-5xl text-ink leading-tight"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              Materials
+            </h1>
+            <p className="mt-2 text-muted max-w-md">
+              Consumables and equipment used across published experiment designs.
+            </p>
+          </div>
+          {user && (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowBulk(true)}
+                className="btn-secondary text-sm"
+              >
+                Bulk upload
+              </button>
+              <Link to="/materials/new" className="btn-primary text-sm">
+                Submit material
+              </Link>
+            </div>
+          )}
+        </div>
+
+        {/* ── Category pills ── */}
+        <div className="mt-6 flex flex-wrap gap-2">
+          <button
+            onClick={() => setCategory('')}
+            className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+              category === ''
+                ? 'bg-ink text-white'
+                : 'bg-white text-ink border border-surface-2 hover:bg-surface-2'
+            }`}
+          >
+            All
+          </button>
+          {CATEGORIES.map(c => (
+            <button
+              key={c.value}
+              onClick={() => setCategory(c.value === category ? '' : c.value)}
+              className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                category === c.value
+                  ? 'bg-ink text-white'
+                  : 'bg-white text-ink border border-surface-2 hover:bg-surface-2'
+              }`}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Divider ── */}
+      <div className="border-t border-surface-2" />
+
+      {/* ── Two-column split ── */}
+      {loading ? (
+        <div className="flex justify-center py-24">
+          <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : (
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-12">
+            {/* Equipment */}
+            <Section
+              title="Equipment"
+              count={equipment.length}
+              accent="#2F1847"
+              materials={equipment}
+              emptyText="No equipment matches your filters."
+            />
+            {/* Consumables */}
+            <Section
+              title="Consumables"
+              count={consumables.length}
+              accent="#C1502D"
+              materials={consumables}
+              emptyText="No consumables match your filters."
+            />
+          </div>
+        </div>
+      )}
+
+      {showBulk && (
+        <BulkUploadMaterialsModal
+          onClose={() => setShowBulk(false)}
+          onComplete={() => { setShowBulk(false); fetch() }}
+        />
+      )}
+    </div>
+  )
+}
+
+function Section({
+  title,
+  count,
+  accent,
+  materials,
+  emptyText,
+}: {
+  title: string
+  count: number
+  accent: string
+  materials: Material[]
+  emptyText: string
+}) {
+  return (
+    <div>
+      {/* Section header */}
+      <div className="flex items-center gap-3 mb-5">
+        <div className="w-1 h-8 rounded-full" style={{ background: accent }} />
+        <div>
+          <h2
+            className="text-xl text-ink leading-none"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            {title}
+          </h2>
+        </div>
+        <span
+          className="ml-auto text-xs font-mono font-medium px-2.5 py-1 rounded-full"
+          style={{ background: accent + '18', color: accent }}
+        >
+          {count}
+        </span>
+      </div>
+
+      {materials.length === 0 ? (
+        <p className="text-sm text-muted py-8 text-center">{emptyText}</p>
+      ) : (
+        <div className="space-y-2">
+          {materials.map(m => <MaterialCard1 key={m.id} material={m} />)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MaterialCard1({ material }: { material: Material }) {
+  const catColor = CATEGORY_COLORS[material.category]
+
+  return (
+    <Link
+      to={`/materials/${material.id}`}
+      className="flex items-start gap-4 bg-white rounded-xl border border-surface-2
+                 px-4 py-3 hover:border-plum hover:shadow-sm transition-all group"
+    >
+      {/* Left accent bar */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start gap-2 flex-wrap">
+          <span className="font-semibold text-ink group-hover:text-primary transition-colors text-[15px]">
+            {material.name}
+          </span>
+          {material.is_verified && (
+            <span className="text-xs font-medium bg-emerald-50 text-emerald-700 px-2 py-0.5 rounded-full">
+              ✓ Verified
+            </span>
+          )}
+        </div>
+
+        {material.description && (
+          <p className="mt-1 text-sm text-muted line-clamp-1">{material.description}</p>
+        )}
+
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <span className={`text-xs font-medium px-2 py-0.5 rounded-full capitalize ${catColor}`}>
+            {material.category}
+          </span>
+          {material.supplier && (
+            <span className="text-xs text-muted">{material.supplier}</span>
+          )}
+          {material.typical_cost_usd != null && (
+            <span className="text-xs text-muted">${material.typical_cost_usd.toFixed(2)}</span>
+          )}
+          {material.tags.slice(0, 3).map(tag => (
+            <span
+              key={tag}
+              className="text-xs px-2 py-0.5 rounded-full bg-blush/40 text-plum"
+              style={{ fontFamily: 'var(--font-mono)' }}
+            >
+              {tag}
+            </span>
+          ))}
+          {material.tags.length > 3 && (
+            <span className="text-xs text-muted">+{material.tags.length - 3}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Arrow */}
+      <svg
+        className="w-4 h-4 text-muted mt-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+      </svg>
+    </Link>
+  )
+}

--- a/frontend/src/pages/Materials2.tsx
+++ b/frontend/src/pages/Materials2.tsx
@@ -1,0 +1,309 @@
+/**
+ * Materials — Option 2: "Science Catalog"
+ *
+ * Structured, information-dense. Dark indigo hero banner, then two stacked
+ * color-coded sections (Equipment / Consumables) each with a full card grid.
+ * Functional and confident — feels like a proper lab inventory.
+ */
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { api } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
+import type { Material, MaterialCategory, MaterialListResponse } from '../types/material'
+import BulkUploadMaterialsModal from '../components/BulkUploadMaterialsModal'
+
+const CATEGORIES: { value: MaterialCategory; label: string }[] = [
+  { value: 'glassware',  label: 'Glassware' },
+  { value: 'reagent',    label: 'Reagent' },
+  { value: 'equipment',  label: 'Equipment' },
+  { value: 'biological', label: 'Biological' },
+  { value: 'other',      label: 'Other' },
+]
+
+const CATEGORY_EMOJI: Record<MaterialCategory, string> = {
+  glassware:  '🫙',
+  reagent:    '⚗️',
+  equipment:  '🔬',
+  biological: '🧬',
+  other:      '📦',
+}
+
+export default function Materials2() {
+  const { user } = useAuth()
+  const [all, setAll] = useState<Material[]>([])
+  const [loading, setLoading] = useState(true)
+  const [category, setCategory] = useState<string>('')
+  const [showBulk, setShowBulk] = useState(false)
+
+  async function fetch() {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams()
+      if (category) params.set('category', category)
+      const qs = params.toString()
+      const res = await api.get<MaterialListResponse>(`/api/materials${qs ? `?${qs}` : ''}`)
+      setAll(res.data)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetch() }, [category])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  const equipment   = all.filter(m => m.type === 'Equipment')
+  const consumables = all.filter(m => m.type === 'Consumable')
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* ── Hero banner ── */}
+      <div style={{ background: 'var(--color-dark)' }} className="text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+          <div className="flex flex-wrap items-center justify-between gap-6">
+            <div>
+              <p
+                className="text-xs tracking-widest uppercase mb-2 opacity-50"
+                style={{ fontFamily: 'var(--font-mono)' }}
+              >
+                Lab inventory
+              </p>
+              <h1
+                className="text-4xl sm:text-5xl font-semibold leading-tight"
+                style={{ fontFamily: 'var(--font-display)' }}
+              >
+                Materials
+              </h1>
+              <p className="mt-2 text-white/60 text-sm max-w-sm">
+                A community-maintained catalog of consumables and equipment.
+              </p>
+            </div>
+
+            {/* Stat + actions */}
+            <div className="flex flex-col items-end gap-4">
+              <div className="flex gap-6 text-right">
+                <div>
+                  <div
+                    className="text-3xl font-semibold"
+                    style={{ fontFamily: 'var(--font-mono)' }}
+                  >
+                    {loading ? '—' : equipment.length}
+                  </div>
+                  <div className="text-xs text-white/50 uppercase tracking-wide">Equipment</div>
+                </div>
+                <div>
+                  <div
+                    className="text-3xl font-semibold"
+                    style={{ fontFamily: 'var(--font-mono)' }}
+                  >
+                    {loading ? '—' : consumables.length}
+                  </div>
+                  <div className="text-xs text-white/50 uppercase tracking-wide">Consumables</div>
+                </div>
+              </div>
+              {user && (
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setShowBulk(true)}
+                    className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border
+                               border-white/30 text-white text-sm font-medium
+                               hover:bg-white/10 transition-colors"
+                  >
+                    Bulk upload
+                  </button>
+                  <Link
+                    to="/materials/new"
+                    className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg
+                               text-sm font-medium transition-colors"
+                    style={{ background: 'var(--color-primary)', color: 'white' }}
+                  >
+                    Submit material
+                  </Link>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Category filter tabs */}
+          <div className="mt-8 flex flex-wrap gap-2">
+            <button
+              onClick={() => setCategory('')}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                category === ''
+                  ? 'bg-white text-dark'
+                  : 'text-white/70 hover:text-white hover:bg-white/10'
+              }`}
+            >
+              All categories
+            </button>
+            {CATEGORIES.map(c => (
+              <button
+                key={c.value}
+                onClick={() => setCategory(c.value === category ? '' : c.value)}
+                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                  category === c.value
+                    ? 'bg-white text-dark'
+                    : 'text-white/70 hover:text-white hover:bg-white/10'
+                }`}
+              >
+                {CATEGORY_EMOJI[c.value]} {c.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Content ── */}
+      {loading ? (
+        <div className="flex justify-center py-24">
+          <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : (
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-12">
+          <CatalogSection
+            title="Equipment"
+            subtitle="Reusable tools and instruments"
+            materials={equipment}
+            bannerColor="#2F1847"
+            tagColor="#C1502D"
+          />
+          <CatalogSection
+            title="Consumables"
+            subtitle="Single-use and replenishable supplies"
+            materials={consumables}
+            bannerColor="#624763"
+            tagColor="#C1502D"
+          />
+        </div>
+      )}
+
+      {showBulk && (
+        <BulkUploadMaterialsModal
+          onClose={() => setShowBulk(false)}
+          onComplete={() => { setShowBulk(false); fetch() }}
+        />
+      )}
+    </div>
+  )
+}
+
+function CatalogSection({
+  title,
+  subtitle,
+  materials,
+  bannerColor,
+  tagColor,
+}: {
+  title: string
+  subtitle: string
+  materials: Material[]
+  bannerColor: string
+  tagColor: string
+}) {
+  return (
+    <div>
+      {/* Section header bar */}
+      <div
+        className="rounded-xl px-5 py-4 flex items-center justify-between mb-5"
+        style={{ background: bannerColor }}
+      >
+        <div>
+          <h2
+            className="text-xl font-semibold text-white leading-tight"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            {title}
+          </h2>
+          <p className="text-white/60 text-sm mt-0.5">{subtitle}</p>
+        </div>
+        <span
+          className="text-white/90 text-lg font-semibold tabular-nums"
+          style={{ fontFamily: 'var(--font-mono)' }}
+        >
+          {materials.length}
+        </span>
+      </div>
+
+      {materials.length === 0 ? (
+        <div className="text-center py-12 text-muted text-sm">Nothing here yet.</div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+          {materials.map(m => (
+            <MaterialCard2 key={m.id} material={m} tagColor={tagColor} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MaterialCard2({
+  material,
+  tagColor,
+}: {
+  material: Material
+  tagColor: string
+}) {
+  return (
+    <Link
+      to={`/materials/${material.id}`}
+      className="group bg-white rounded-xl border border-gray-200 p-4
+                 hover:shadow-md hover:border-gray-300 transition-all flex flex-col gap-3"
+    >
+      {/* Top row */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold text-ink group-hover:text-primary transition-colors leading-snug">
+            {material.name}
+          </p>
+          {material.supplier && (
+            <p className="text-xs text-muted mt-0.5">{material.supplier}</p>
+          )}
+        </div>
+        {material.is_verified && (
+          <span className="shrink-0 text-xs font-medium bg-emerald-50 text-emerald-700 px-2 py-0.5 rounded-full">
+            ✓
+          </span>
+        )}
+      </div>
+
+      {/* Description */}
+      {material.description && (
+        <p className="text-sm text-muted line-clamp-2 leading-snug">{material.description}</p>
+      )}
+
+      {/* Bottom metadata */}
+      <div className="mt-auto pt-2 border-t border-gray-100 flex items-center justify-between gap-2">
+        <span className="text-xs font-medium capitalize text-muted">{material.category}</span>
+        {material.typical_cost_usd != null && (
+          <span
+            className="text-xs font-medium"
+            style={{ fontFamily: 'var(--font-mono)', color: tagColor }}
+          >
+            ${material.typical_cost_usd.toFixed(2)}
+          </span>
+        )}
+      </div>
+
+      {/* Tags */}
+      {material.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {material.tags.slice(0, 4).map(tag => (
+            <span
+              key={tag}
+              className="text-xs px-2 py-0.5 rounded-md"
+              style={{
+                fontFamily: 'var(--font-mono)',
+                background: '#EABFCB40',
+                color: '#624763',
+              }}
+            >
+              {tag}
+            </span>
+          ))}
+          {material.tags.length > 4 && (
+            <span className="text-xs text-muted">+{material.tags.length - 4}</span>
+          )}
+        </div>
+      )}
+    </Link>
+  )
+}

--- a/frontend/src/pages/Materials3.tsx
+++ b/frontend/src/pages/Materials3.tsx
@@ -1,0 +1,357 @@
+/**
+ * Materials — Option 3: "Science Fair"
+ *
+ * The playful one. Big personality, fun copy, bold color blocks.
+ * Equipment and Consumables each get their own strongly-branded hero header.
+ * Tags are front-and-center. Cards have color and character.
+ *
+ * This is intentionally a little too much — pare back to taste.
+ */
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { api } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
+import type { Material, MaterialCategory, MaterialListResponse } from '../types/material'
+import BulkUploadMaterialsModal from '../components/BulkUploadMaterialsModal'
+
+const CATEGORIES: { value: MaterialCategory; label: string; emoji: string }[] = [
+  { value: 'glassware',  label: 'Glassware',  emoji: '🫙' },
+  { value: 'reagent',    label: 'Reagent',    emoji: '⚗️' },
+  { value: 'equipment',  label: 'Equipment',  emoji: '🔬' },
+  { value: 'biological', label: 'Biological', emoji: '🧬' },
+  { value: 'other',      label: 'Other',      emoji: '📦' },
+]
+
+const CATEGORY_DOT: Record<MaterialCategory, string> = {
+  glassware:  'bg-sky-400',
+  reagent:    'bg-amber-400',
+  equipment:  'bg-emerald-400',
+  biological: 'bg-violet-400',
+  other:      'bg-gray-400',
+}
+
+export default function Materials3() {
+  const { user } = useAuth()
+  const [all, setAll] = useState<Material[]>([])
+  const [loading, setLoading] = useState(true)
+  const [category, setCategory] = useState<string>('')
+  const [showBulk, setShowBulk] = useState(false)
+
+  async function fetch() {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams()
+      if (category) params.set('category', category)
+      const qs = params.toString()
+      const res = await api.get<MaterialListResponse>(`/api/materials${qs ? `?${qs}` : ''}`)
+      setAll(res.data)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetch() }, [category])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  const equipment   = all.filter(m => m.type === 'Equipment')
+  const consumables = all.filter(m => m.type === 'Consumable')
+
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--color-surface)' }}>
+      {/* ── Top header ── */}
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-12 pb-8">
+        <div className="flex flex-wrap items-start justify-between gap-6">
+          <div>
+            <h1
+              className="text-5xl sm:text-6xl text-ink"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              Materials
+            </h1>
+            <p className="mt-3 text-lg text-plum max-w-sm leading-snug">
+              Everything your experiment needs.{' '}
+              <span className="text-muted text-base">No guarantees it fits in the budget.</span>
+            </p>
+          </div>
+
+          {user && (
+            <div className="flex flex-col sm:flex-row gap-2 pt-1">
+              <button
+                onClick={() => setShowBulk(true)}
+                className="inline-flex items-center justify-center gap-2 px-4 py-2.5
+                           rounded-xl border-2 border-plum text-plum text-sm font-semibold
+                           hover:bg-plum hover:text-white transition-all"
+              >
+                {/* Upload icon */}
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+                </svg>
+                Bulk upload
+              </button>
+              <Link
+                to="/materials/new"
+                className="inline-flex items-center justify-center gap-2 px-4 py-2.5
+                           rounded-xl text-sm font-semibold text-white transition-all
+                           hover:opacity-90 active:scale-95"
+                style={{ background: 'var(--color-primary)' }}
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5}
+                    d="M12 4v16m8-8H4" />
+                </svg>
+                Submit material
+              </Link>
+            </div>
+          )}
+        </div>
+
+        {/* ── Category filter ── */}
+        <div className="mt-8 flex flex-wrap gap-2">
+          <button
+            onClick={() => setCategory('')}
+            className={`flex items-center gap-1.5 px-3.5 py-2 rounded-xl text-sm font-medium
+                        border-2 transition-all ${
+              category === ''
+                ? 'border-ink bg-ink text-white'
+                : 'border-surface-2 bg-white text-ink hover:border-ink'
+            }`}
+          >
+            All
+          </button>
+          {CATEGORIES.map(c => (
+            <button
+              key={c.value}
+              onClick={() => setCategory(c.value === category ? '' : c.value)}
+              className={`flex items-center gap-1.5 px-3.5 py-2 rounded-xl text-sm font-medium
+                          border-2 transition-all ${
+                category === c.value
+                  ? 'border-ink bg-ink text-white'
+                  : 'border-surface-2 bg-white text-ink hover:border-ink'
+              }`}
+            >
+              <span>{c.emoji}</span> {c.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-24">
+          <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : (
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pb-16 space-y-14">
+          {/* ── Equipment section ── */}
+          <TypeSection
+            type="Equipment"
+            icon={<GearIcon />}
+            tagline="The tools that keep on giving."
+            bannerBg="#2F1847"
+            accentColor="#C1502D"
+            materials={equipment}
+          />
+
+          {/* ── Consumables section ── */}
+          <TypeSection
+            type="Consumables"
+            icon={<FlaskIcon />}
+            tagline="Stuff you'll go through faster than you think."
+            bannerBg="#C1502D"
+            accentColor="#2F1847"
+            materials={consumables}
+          />
+        </div>
+      )}
+
+      {showBulk && (
+        <BulkUploadMaterialsModal
+          onClose={() => setShowBulk(false)}
+          onComplete={() => { setShowBulk(false); fetch() }}
+        />
+      )}
+    </div>
+  )
+}
+
+function TypeSection({
+  type,
+  icon,
+  tagline,
+  bannerBg,
+  accentColor,
+  materials,
+}: {
+  type: string
+  icon: React.ReactNode
+  tagline: string
+  bannerBg: string
+  accentColor: string
+  materials: Material[]
+}) {
+  return (
+    <div>
+      {/* Section hero */}
+      <div
+        className="rounded-2xl p-6 sm:p-8 flex items-center justify-between gap-6 mb-6"
+        style={{ background: bannerBg }}
+      >
+        <div className="flex items-center gap-5">
+          <div
+            className="w-14 h-14 rounded-xl flex items-center justify-center shrink-0"
+            style={{ background: 'rgba(255,255,255,0.12)' }}
+          >
+            <span className="text-white w-7 h-7">{icon}</span>
+          </div>
+          <div>
+            <h2
+              className="text-3xl font-semibold text-white"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              {type}
+            </h2>
+            <p className="text-white/60 text-sm mt-0.5">{tagline}</p>
+          </div>
+        </div>
+        <div
+          className="shrink-0 text-4xl font-semibold text-white/30 tabular-nums"
+          style={{ fontFamily: 'var(--font-mono)' }}
+        >
+          {materials.length}
+        </div>
+      </div>
+
+      {/* Cards */}
+      {materials.length === 0 ? (
+        <EmptyState type={type} />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {materials.map(m => (
+            <MaterialCard3 key={m.id} material={m} accentColor={accentColor} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MaterialCard3({
+  material,
+  accentColor,
+}: {
+  material: Material
+  accentColor: string
+}) {
+  const catInfo = CATEGORIES.find(c => c.value === material.category)
+  const dotColor = CATEGORY_DOT[material.category]
+
+  return (
+    <Link
+      to={`/materials/${material.id}`}
+      className="group bg-white rounded-2xl border-2 border-surface-2 p-4
+                 hover:border-current hover:shadow-lg transition-all flex flex-col gap-3"
+      style={{ '--tw-border-opacity': '1' } as React.CSSProperties}
+    >
+      {/* Category badge row */}
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-1.5 text-xs font-medium text-muted">
+          <span className={`w-2 h-2 rounded-full ${dotColor}`} />
+          {catInfo?.emoji} {catInfo?.label ?? material.category}
+        </span>
+        {material.is_verified && (
+          <span className="text-xs font-semibold text-emerald-600">✓ Verified</span>
+        )}
+      </div>
+
+      {/* Name */}
+      <p
+        className="font-semibold text-ink text-[15px] leading-snug
+                   group-hover:text-primary transition-colors"
+      >
+        {material.name}
+      </p>
+
+      {/* Description */}
+      {material.description && (
+        <p className="text-sm text-muted line-clamp-2 leading-snug">{material.description}</p>
+      )}
+
+      {/* Tags — very prominent */}
+      {material.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {material.tags.slice(0, 5).map(tag => (
+            <span
+              key={tag}
+              className="text-xs px-2.5 py-1 rounded-lg font-medium"
+              style={{
+                fontFamily: 'var(--font-mono)',
+                background: accentColor + '15',
+                color: accentColor,
+              }}
+            >
+              #{tag}
+            </span>
+          ))}
+          {material.tags.length > 5 && (
+            <span className="text-xs text-muted self-center">+{material.tags.length - 5}</span>
+          )}
+        </div>
+      )}
+
+      {/* Bottom: supplier + cost */}
+      {(material.supplier || material.typical_cost_usd != null) && (
+        <div className="mt-auto pt-2 border-t border-surface flex items-center justify-between gap-2">
+          {material.supplier && (
+            <span className="text-xs text-muted truncate">{material.supplier}</span>
+          )}
+          {material.typical_cost_usd != null && (
+            <span
+              className="text-xs font-semibold shrink-0"
+              style={{ fontFamily: 'var(--font-mono)', color: accentColor }}
+            >
+              ${material.typical_cost_usd.toFixed(2)}
+            </span>
+          )}
+        </div>
+      )}
+    </Link>
+  )
+}
+
+function EmptyState({ type }: { type: string }) {
+  const msg = type === 'Equipment'
+    ? "No equipment here yet. Your lab feels a little sparse."
+    : "No consumables yet. Stock up — science is thirsty."
+  return (
+    <div className="text-center py-16 px-4">
+      <div className="text-5xl mb-3">{type === 'Equipment' ? '🔬' : '🧪'}</div>
+      <p className="text-muted text-sm">{msg}</p>
+    </div>
+  )
+}
+
+function GearIcon() {
+  return (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="w-full h-full">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+        d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573
+           1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426
+           1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37
+           2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724
+           1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0
+           00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0
+           001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07
+           2.572-1.065z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  )
+}
+
+function FlaskIcon() {
+  return (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="w-full h-full">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+        d="M9 3h6m-6 0v7l-4 9a1 1 0 00.9 1.45h12.2A1 1 0 0019 19l-4-9V3m-6 0h6" />
+    </svg>
+  )
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,6 +7,7 @@ export default {
   theme: {
     extend: {
       colors: {
+        // Legacy brand scale (kept for compatibility during migration)
         brand: {
           50:  '#f0f9ff',
           100: '#e0f2fe',
@@ -19,11 +20,52 @@ export default {
           800: '#075985',
           900: '#0c4a6e',
         },
+        // Replic design system palette
+        primary:  '#C1502D', // Burnt Sienna — CTAs, active states
+        dark:     '#2F1847', // Deep Indigo — dark backgrounds, headings
+        plum:     '#624763', // Dusty Plum — secondary elements, hover
+        blush:    '#EABFCB', // Blush — badges, chips, highlights
+        surface:  '#F5EAE0', // Warm White — page bg, cards
+        ink:      '#1A1025', // Near-black (warm) — body text
+        muted:    '#8C7D8E', // Mid gray — secondary / placeholder
+        'surface-2': '#EDE0D5', // Slightly deeper warm — borders, alt bg
       },
       fontFamily: {
-        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        display: ['Fraunces', 'Georgia', 'serif'],
+        body:    ['Plus Jakarta Sans', 'system-ui', 'sans-serif'],
+        mono:    ['"DM Mono"', '"Courier New"', 'monospace'],
+        sans:    ['Plus Jakarta Sans', 'system-ui', 'sans-serif'],
       },
     },
   },
-  plugins: [],
+  plugins: [require('daisyui')],
+  daisyui: {
+    themes: [
+      {
+        replic: {
+          'primary':          '#C1502D',
+          'primary-content':  '#ffffff',
+          'secondary':        '#624763',
+          'secondary-content':'#ffffff',
+          'accent':           '#EABFCB',
+          'accent-content':   '#1A1025',
+          'neutral':          '#2F1847',
+          'neutral-content':  '#ffffff',
+          'base-100':         '#F5EAE0',
+          'base-200':         '#EDE0D5',
+          'base-300':         '#DDD0C8',
+          'base-content':     '#1A1025',
+          'info':             '#7dd3fc',
+          'info-content':     '#0c4a6e',
+          'success':          '#86efac',
+          'success-content':  '#14532d',
+          'warning':          '#fde68a',
+          'warning-content':  '#78350f',
+          'error':            '#fca5a5',
+          'error-content':    '#7f1d1d',
+        },
+      },
+    ],
+    logs: false,
+  },
 }


### PR DESCRIPTION
## Summary

This PR delivers the full Materials feature from issues #42–#44, the bulk CSV upload from #51, and three design explorations for issue #45 (UI overhaul).

---

## Issues resolved

- Closes #42 — Materials data schema and API
- Closes #43 — Materials browse page and detail view
- Closes #44 — Submit a Material form
- Closes #51 — Bulk upload materials via CSV
- Refs #45 — UI style overhaul (design explorations)

---

## 1. Materials backend (issues #42–#44)

- Firestore schema for `materials` collection: `name`, `type` (`Consumable | Equipment`), `category`, `description`, `safety_notes`, `tags`, `link`, `image_url`, `supplier`, `typical_cost_usd`, `is_verified`, `created_by`, `created_at`, `updated_at`
- `POST /api/materials` — create a material (auth required)
- `GET /api/materials` — paginated list with optional `?category=` filter
- `GET /api/materials/:id` — single material
- `PATCH /api/materials/:id` — update (owner only)
- Composite Firestore index for `created_at` pagination
- Documented in `docs/API.md`

## 2. Materials frontend (issues #43–#44)

- **`Materials.tsx`** — browse page: category filter dropdown, paginated card list with Load More
- **`MaterialDetail.tsx`** — full detail view with all fields, tags, link, image
- **`CreateMaterial.tsx`** + **`MaterialForm.tsx`** — multi-field form with image upload
- **`ImageUpload.tsx`** — Firebase Storage upload component with preview
- Routes added to `App.tsx`, `Navbar.tsx` updated with Materials link

## 3. Bulk CSV upload (issue #51)

- **`BulkUploadMaterialsModal.tsx`** — RFC 4180-compatible CSV parser, sequential row submission to `POST /api/materials`, real-time progress counter, row-level success/failure summary
- Required columns: `name`, `type`, `category`
- Optional columns: `description`, `safety_notes`, `tags`, `link`, `supplier`, `typical_cost_usd`, `image_url` (forward-compatible)
- "Bulk upload" button on the Materials page (authenticated users only)

## 4. Design system (issue #45)

### Global setup

- **DaisyUI v3** installed with a custom `replic` theme mapping DaisyUI tokens to the palette
- **Google Fonts**: Fraunces (display), Plus Jakarta Sans (body/UI), DM Mono (tags/mono)
- **CSS custom properties** (`--color-primary`, `--color-dark`, `--color-secondary`, `--color-accent`, `--color-surface`, `--color-text`, `--color-text-muted`) and font variables
- **Tailwind tokens**: `primary`, `dark`, `plum`, `blush`, `surface`, `ink`, `muted`, `surface-2` colors; `font-display`, `font-body`, `font-mono` families
- `.btn-primary`, `.btn-secondary`, `.card`, `.input-sm` updated to use new palette

### Three Materials page explorations

Accessible via the **Preview** dropdown in the nav bar.

#### `/materials-1` — "Specimen Cabinet"
Warm and editorial. Equipment and Consumables in side-by-side columns on a warm `surface` background. Category pill filters. Cards are compact with left accent bars and DM Mono tag chips. The "just right" option — calm and purposeful.

#### `/materials-2` — "Science Catalog"
Confident and structured. Deep indigo hero banner with live type counts and action buttons, category filter tabs inline in the banner. Two stacked sections below — each with a color-coded header bar (indigo/plum) and a 3-column grid. Feels like a proper lab inventory system.

#### `/materials-3` — "Science Fair" _(the playful one)_
Big Fraunces title with a cheeky subtitle. Equipment and Consumables each get a large hero block with a custom SVG icon and a one-liner. Tags display as `#hashtag` chips. Fun, personality-forward empty states. Cards have `rounded-2xl` and bold hover borders. Intentionally a bit much — use it for parts to cherry-pick.

---

## Test plan

- [ ] `GET /api/materials` returns paginated results; `?category=` filter works
- [ ] `POST /api/materials` creates a material and requires auth
- [ ] Materials browse page loads, category filter updates list, Load More paginates
- [ ] Material detail page renders all fields
- [ ] Create Material form submits correctly with and without an image
- [ ] Bulk upload: valid CSV creates materials; invalid rows show per-row errors; progress is shown
- [ ] All three preview pages render Equipment and Consumables in separate sections
- [ ] Category filter on preview pages updates both sections
- [ ] Bulk upload + Submit material buttons visible for authenticated users on all pages
- [ ] `npm run build` passes

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15