### PR TITLE
Bug fixes, user role/admin fields, Materials redesign + global warm background

### DIFF
--- a/backend/src/types/user.ts
+++ b/backend/src/types/user.ts
@@ -6,6 +6,25 @@ export interface UserScores {
   reviewer: number
 }
 
+export type UserRole =
+  | 'citizen_scientist'
+  | 'student'
+  | 'teacher'
+  | 'professional_researcher'
+  | 'industry_professional'
+  | 'hobbyist'
+  | 'other'
+
+export const USER_ROLES: { value: UserRole; label: string }[] = [
+  { value: 'citizen_scientist',    label: 'Citizen Scientist' },
+  { value: 'student',              label: 'Student' },
+  { value: 'teacher',              label: 'Teacher / Educator' },
+  { value: 'professional_researcher', label: 'Professional Researcher' },
+  { value: 'industry_professional',label: 'Industry Professional' },
+  { value: 'hobbyist',             label: 'Hobbyist' },
+  { value: 'other',                label: 'Other' },
+]
+
 export interface UserProfile {
   uid: string
   displayName: string
@@ -13,6 +32,8 @@ export interface UserProfile {
   photoURL: string | null
   bio: string | null
   affiliation: string | null
+  role: UserRole | null
+  is_admin: boolean
   scores: UserScores
   createdAt: Timestamp
   updatedAt: Timestamp
@@ -30,4 +51,6 @@ export interface UpdateUserBody {
   photoURL?: string | null
   bio?: string | null
   affiliation?: string | null
+  role?: UserRole | null
+  // is_admin is intentionally excluded — not user-settable
 }

--- a/frontend/src/components/MaterialForm.tsx
+++ b/frontend/src/components/MaterialForm.tsx
@@ -4,7 +4,7 @@ import ImageUpload from './ImageUpload'
 const CATEGORY_OPTIONS: { value: MaterialCategory; label: string }[] = [
   { value: 'glassware', label: 'Glassware' },
   { value: 'reagent', label: 'Reagent' },
-  { value: 'equipment', label: 'Equipment' },
+  { value: 'equipment', label: 'Instruments' },
   { value: 'biological', label: 'Biological' },
   { value: 'other', label: 'Other' },
 ]

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,7 +26,8 @@
   }
 
   body {
-    @apply bg-gray-50 text-gray-900;
+    background: var(--color-surface);
+    color: var(--color-text);
   }
 }
 

--- a/frontend/src/pages/Materials.tsx
+++ b/frontend/src/pages/Materials.tsx
@@ -5,199 +5,334 @@ import { useAuth } from '../contexts/AuthContext'
 import type { Material, MaterialCategory, MaterialListResponse } from '../types/material'
 import BulkUploadMaterialsModal from '../components/BulkUploadMaterialsModal'
 
-const CATEGORY_OPTIONS: { value: MaterialCategory; label: string }[] = [
-  { value: 'glassware', label: 'Glassware' },
-  { value: 'reagent', label: 'Reagent' },
-  { value: 'equipment', label: 'Equipment' },
-  { value: 'biological', label: 'Biological' },
-  { value: 'other', label: 'Other' },
+const CATEGORIES: { value: MaterialCategory; label: string; emoji: string }[] = [
+  { value: 'glassware',  label: 'Glassware',   emoji: '🫙' },
+  { value: 'reagent',    label: 'Reagent',     emoji: '⚗️' },
+  { value: 'equipment',  label: 'Instruments', emoji: '🔬' },
+  { value: 'biological', label: 'Biological',  emoji: '🧬' },
+  { value: 'other',      label: 'Other',       emoji: '📦' },
 ]
 
 export default function Materials() {
   const { user } = useAuth()
-  const [materials, setMaterials] = useState<Material[]>([])
-  const [cursor, setCursor] = useState<string | undefined>()
+  const [all, setAll] = useState<Material[]>([])
   const [loading, setLoading] = useState(true)
-  const [loadingMore, setLoadingMore] = useState(false)
   const [category, setCategory] = useState('')
   const [showBulkUpload, setShowBulkUpload] = useState(false)
-
-  function buildQuery(after?: string) {
-    const params = new URLSearchParams()
-    if (category) params.set('category', category)
-    if (after) params.set('after', after)
-    const qs = params.toString()
-    return `/api/materials${qs ? `?${qs}` : ''}`
-  }
 
   async function fetchMaterials() {
     setLoading(true)
     try {
-      const res = await api.get<MaterialListResponse>(buildQuery())
-      setMaterials(res.data)
-      setCursor(res.data.length === 20 ? res.data[res.data.length - 1]?.id : undefined)
+      const params = new URLSearchParams()
+      if (category) params.set('category', category)
+      const qs = params.toString()
+      const res = await api.get<MaterialListResponse>(`/api/materials${qs ? `?${qs}` : ''}`)
+      setAll(res.data)
     } finally {
       setLoading(false)
     }
   }
 
-  async function loadMore() {
-    if (!cursor) return
-    setLoadingMore(true)
-    try {
-      const res = await api.get<MaterialListResponse>(buildQuery(cursor))
-      setMaterials((prev) => [...prev, ...res.data])
-      setCursor(res.data.length === 20 ? res.data[res.data.length - 1]?.id : undefined)
-    } finally {
-      setLoadingMore(false)
-    }
-  }
+  useEffect(() => { fetchMaterials() }, [category])  // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    fetchMaterials()
-  }, [category])
+  const equipment   = all.filter(m => m.type === 'Equipment')
+  const consumables = all.filter(m => m.type === 'Consumable')
 
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4">
-      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Materials</h1>
-          <p className="mt-2 text-gray-600">Browse the catalog of consumables and equipment used in experiment designs.</p>
-        </div>
-        {user && (
-          <div className="flex gap-2 shrink-0">
-            <button
-              onClick={() => setShowBulkUpload(true)}
-              className="btn-secondary text-sm"
+    <div className="min-h-screen" style={{ background: 'var(--color-surface)' }}>
+
+      {/* ── Page header ── */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-6">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h1
+              className="text-5xl sm:text-6xl text-ink"
+              style={{ fontFamily: 'var(--font-display)' }}
             >
-              Bulk upload
-            </button>
-            <Link to="/materials/new" className="btn-primary text-sm">
-              Submit material
-            </Link>
-          </div>
-        )}
-      </div>
-
-      {/* Filters */}
-      <div className="flex flex-wrap gap-3 mb-6">
-        <select
-          value={category}
-          onChange={(e) => setCategory(e.target.value)}
-          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
-        >
-          <option value="">All categories</option>
-          {CATEGORY_OPTIONS.map(({ value, label }) => (
-            <option key={value} value={value}>{label}</option>
-          ))}
-        </select>
-      </div>
-
-      {loading ? (
-        <div className="flex justify-center py-20">
-          <div className="w-8 h-8 border-4 border-brand-600 border-t-transparent rounded-full animate-spin" />
-        </div>
-      ) : materials.length === 0 ? (
-        <div className="card p-12 flex flex-col items-center text-center">
-          <div className="text-5xl mb-4">🧪</div>
-          <h2 className="text-lg font-semibold text-gray-900">No materials found</h2>
-          <p className="mt-2 text-sm text-gray-500 max-w-sm">
-            Try adjusting your filters or check back soon.
-          </p>
-        </div>
-      ) : (
-        <>
-          <div className="space-y-3">
-            {materials.map((material) => (
-              <MaterialCard key={material.id} material={material} />
-            ))}
+              Materials
+            </h1>
+            <p className="mt-2 text-lg text-plum max-w-sm">
+              Everything your experiment needs.{' '}
+              <span className="text-muted text-base">No guarantees it fits in the budget.</span>
+            </p>
           </div>
 
-          {cursor && (
-            <div className="mt-6 text-center">
+          {user && (
+            <div className="flex items-center gap-2 shrink-0">
               <button
-                onClick={loadMore}
-                disabled={loadingMore}
-                className="btn-secondary text-sm disabled:opacity-50"
+                onClick={() => setShowBulkUpload(true)}
+                className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-xl
+                           border-2 border-plum text-plum text-sm font-semibold
+                           hover:bg-plum hover:text-white transition-all"
               >
-                {loadingMore ? 'Loading…' : 'Load more'}
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+                </svg>
+                Bulk upload
               </button>
+              <Link
+                to="/materials/new"
+                className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-xl
+                           text-sm font-semibold text-white hover:opacity-90 transition-all"
+                style={{ background: 'var(--color-primary)' }}
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+                </svg>
+                Submit material
+              </Link>
             </div>
           )}
-        </>
+        </div>
+
+        {/* ── Category pill filters ── */}
+        <div className="mt-6 flex flex-wrap gap-2">
+          <CategoryPill label="All" active={category === ''} onClick={() => setCategory('')} />
+          {CATEGORIES.map(c => (
+            <CategoryPill
+              key={c.value}
+              label={`${c.emoji} ${c.label}`}
+              active={category === c.value}
+              onClick={() => setCategory(category === c.value ? '' : c.value)}
+            />
+          ))}
+        </div>
+
+        {/* ── Mobile jump links (hidden on lg+) ── */}
+        <div className="mt-4 flex gap-3 lg:hidden">
+          <a
+            href="#section-equipment"
+            className="inline-flex items-center gap-1 text-sm font-medium text-white
+                       px-3 py-1.5 rounded-lg hover:opacity-80 transition-opacity"
+            style={{ background: 'var(--color-dark)' }}
+          >
+            ↓ Equipment
+          </a>
+          <a
+            href="#section-consumables"
+            className="inline-flex items-center gap-1 text-sm font-medium text-white
+                       px-3 py-1.5 rounded-lg hover:opacity-80 transition-opacity"
+            style={{ background: 'var(--color-primary)' }}
+          >
+            ↓ Consumables
+          </a>
+        </div>
+      </div>
+
+      {/* ── Sections ── */}
+      {loading ? (
+        <div className="flex justify-center py-24">
+          <div
+            className="w-8 h-8 border-4 rounded-full animate-spin"
+            style={{ borderColor: 'var(--color-primary)', borderTopColor: 'transparent' }}
+          />
+        </div>
+      ) : (
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <MaterialsSection
+              id="section-equipment"
+              title="Equipment"
+              subtitle="The tools that keep on giving."
+              icon={<GearIcon />}
+              bannerBg="var(--color-dark)"
+              accentColor="var(--color-primary)"
+              materials={equipment}
+              emptyMsg="No equipment here yet. Your lab feels a little sparse."
+              emptyEmoji="🔬"
+            />
+            <MaterialsSection
+              id="section-consumables"
+              title="Consumables"
+              subtitle="Stuff you'll go through faster than you think."
+              icon={<FlaskIcon />}
+              bannerBg="var(--color-primary)"
+              accentColor="var(--color-dark)"
+              materials={consumables}
+              emptyMsg="No consumables yet. Stock up — science is thirsty."
+              emptyEmoji="🧪"
+            />
+          </div>
+        </div>
       )}
+
       {showBulkUpload && (
         <BulkUploadMaterialsModal
           onClose={() => setShowBulkUpload(false)}
-          onComplete={() => {
-            setShowBulkUpload(false)
-            fetchMaterials()
-          }}
+          onComplete={() => { setShowBulkUpload(false); fetchMaterials() }}
         />
       )}
     </div>
   )
 }
 
-function MaterialCard({ material }: { material: Material }) {
+function CategoryPill({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
   return (
-    <Link
-      to={`/materials/${material.id}`}
-      className="block card p-5 hover:shadow-md transition-shadow"
+    <button
+      onClick={onClick}
+      className={`flex items-center gap-1.5 px-3.5 py-2 rounded-xl text-sm font-medium
+                  border-2 transition-all ${
+        active
+          ? 'border-ink bg-ink text-white'
+          : 'border-surface-2 bg-white text-ink hover:border-ink'
+      }`}
     >
-      <div className="flex items-start gap-4">
-        {material.image_url && (
-          <img
-            src={material.image_url}
-            alt={material.name}
-            className="h-14 w-14 object-cover rounded-lg border border-gray-200 shrink-0"
-          />
-        )}
-        <div className="flex-1 min-w-0 flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2 flex-wrap">
-              <h3 className="font-semibold text-gray-900">{material.name}</h3>
-              {material.is_verified && (
-                <span className="text-xs font-medium bg-green-50 text-green-700 px-2 py-0.5 rounded-full">
-                  Verified
-                </span>
-              )}
-            </div>
-            {material.description && (
-              <p className="mt-1 text-sm text-gray-600 line-clamp-2">{material.description}</p>
-            )}
+      {label}
+    </button>
+  )
+}
+
+function MaterialsSection({
+  id,
+  title,
+  subtitle,
+  icon,
+  bannerBg,
+  accentColor,
+  materials,
+  emptyMsg,
+  emptyEmoji,
+}: {
+  id: string
+  title: string
+  subtitle: string
+  icon: React.ReactNode
+  bannerBg: string
+  accentColor: string
+  materials: Material[]
+  emptyMsg: string
+  emptyEmoji: string
+}) {
+  return (
+    <div id={id} className="flex flex-col">
+      {/* Hero banner */}
+      <div
+        className="rounded-2xl px-6 py-5 flex items-center justify-between gap-4 mb-4"
+        style={{ background: bannerBg }}
+      >
+        <div className="flex items-center gap-4">
+          <div
+            className="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
+            style={{ background: 'rgba(255,255,255,0.12)' }}
+          >
+            <span className="text-white w-6 h-6">{icon}</span>
           </div>
-          <span className="shrink-0 text-xs font-medium bg-brand-50 text-brand-700 px-2 py-0.5 rounded-full capitalize">
-            {material.type}
-          </span>
+          <div>
+            <h2
+              className="text-2xl font-semibold text-white leading-tight"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              {title}
+            </h2>
+            <p className="text-white/60 text-sm">{subtitle}</p>
+          </div>
         </div>
+        <span
+          className="text-white/40 text-3xl font-semibold tabular-nums shrink-0"
+          style={{ fontFamily: 'var(--font-mono)' }}
+        >
+          {materials.length}
+        </span>
       </div>
 
-      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-gray-500">
-        <span className="capitalize">{material.category}</span>
-        {material.typical_cost_usd != null && (
-          <>
-            <span>·</span>
-            <span>${material.typical_cost_usd.toFixed(2)}</span>
-          </>
-        )}
-        {material.supplier && (
-          <>
-            <span>·</span>
-            <span>{material.supplier}</span>
-          </>
-        )}
-      </div>
-
-      {material.tags.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1.5">
-          {material.tags.map((tag) => (
-            <span key={tag} className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
-              {tag}
-            </span>
+      {/* Card list */}
+      {materials.length === 0 ? (
+        <div className="flex-1 flex flex-col items-center justify-center py-12 text-center">
+          <div className="text-5xl mb-3">{emptyEmoji}</div>
+          <p className="text-muted text-sm">{emptyMsg}</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {materials.map(m => (
+            <MaterialCard key={m.id} material={m} accentColor={accentColor} />
           ))}
         </div>
       )}
+    </div>
+  )
+}
+
+function MaterialCard({ material, accentColor }: { material: Material; accentColor: string }) {
+  const catInfo = CATEGORIES.find(c => c.value === material.category)
+
+  return (
+    <Link
+      to={`/materials/${material.id}`}
+      className="group bg-white rounded-2xl border-2 border-surface-2 px-4 py-3
+                 hover:border-plum hover:shadow-md transition-all flex flex-col gap-2"
+    >
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-1 text-xs font-medium text-muted">
+          {catInfo?.emoji} {catInfo?.label ?? material.category}
+        </span>
+        {material.is_verified && (
+          <span className="text-xs font-semibold text-emerald-600">✓ Verified</span>
+        )}
+      </div>
+
+      <p className="font-semibold text-ink text-[15px] leading-snug group-hover:text-primary transition-colors">
+        {material.name}
+      </p>
+
+      {material.description && (
+        <p className="text-sm text-muted line-clamp-1">{material.description}</p>
+      )}
+
+      {material.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {material.tags.slice(0, 4).map(tag => (
+            <span
+              key={tag}
+              className="text-xs px-2 py-0.5 rounded-lg font-medium"
+              style={{ fontFamily: 'var(--font-mono)', background: accentColor + '18', color: accentColor }}
+            >
+              #{tag}
+            </span>
+          ))}
+          {material.tags.length > 4 && (
+            <span className="text-xs text-muted self-center">+{material.tags.length - 4}</span>
+          )}
+        </div>
+      )}
+
+      {(material.supplier || material.typical_cost_usd != null) && (
+        <div className="pt-1 border-t border-surface flex items-center justify-between gap-2">
+          {material.supplier && <span className="text-xs text-muted truncate">{material.supplier}</span>}
+          {material.typical_cost_usd != null && (
+            <span
+              className="text-xs font-semibold shrink-0"
+              style={{ fontFamily: 'var(--font-mono)', color: accentColor }}
+            >
+              ${material.typical_cost_usd.toFixed(2)}
+            </span>
+          )}
+        </div>
+      )}
     </Link>
+  )
+}
+
+function GearIcon() {
+  return (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="w-full h-full">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+        d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94
+           3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724
+           1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572
+           1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31
+           -.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724
+           1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  )
+}
+
+function FlaskIcon() {
+  return (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" className="w-full h-full">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+        d="M9 3h6m-6 0v7l-4 9a1 1 0 00.9 1.45h12.2A1 1 0 0019 19l-4-9V3m-6 0h6" />
+    </svg>
   )
 }

--- a/frontend/src/pages/Materials1.tsx
+++ b/frontend/src/pages/Materials1.tsx
@@ -14,7 +14,7 @@ import BulkUploadMaterialsModal from '../components/BulkUploadMaterialsModal'
 const CATEGORIES: { value: MaterialCategory; label: string }[] = [
   { value: 'glassware',  label: 'Glassware' },
   { value: 'reagent',    label: 'Reagent' },
-  { value: 'equipment',  label: 'Equipment' },
+  { value: 'equipment',  label: 'Instruments' },
   { value: 'biological', label: 'Biological' },
   { value: 'other',      label: 'Other' },
 ]

--- a/frontend/src/pages/Materials2.tsx
+++ b/frontend/src/pages/Materials2.tsx
@@ -15,7 +15,7 @@ import BulkUploadMaterialsModal from '../components/BulkUploadMaterialsModal'
 const CATEGORIES: { value: MaterialCategory; label: string }[] = [
   { value: 'glassware',  label: 'Glassware' },
   { value: 'reagent',    label: 'Reagent' },
-  { value: 'equipment',  label: 'Equipment' },
+  { value: 'equipment',  label: 'Instruments' },
   { value: 'biological', label: 'Biological' },
   { value: 'other',      label: 'Other' },
 ]

--- a/frontend/src/pages/Materials3.tsx
+++ b/frontend/src/pages/Materials3.tsx
@@ -17,7 +17,7 @@ import BulkUploadMaterialsModal from '../components/BulkUploadMaterialsModal'
 const CATEGORIES: { value: MaterialCategory; label: string; emoji: string }[] = [
   { value: 'glassware',  label: 'Glassware',  emoji: '🫙' },
   { value: 'reagent',    label: 'Reagent',    emoji: '⚗️' },
-  { value: 'equipment',  label: 'Equipment',  emoji: '🔬' },
+  { value: 'equipment',  label: 'Instruments',  emoji: '🔬' },
   { value: 'biological', label: 'Biological', emoji: '🧬' },
   { value: 'other',      label: 'Other',      emoji: '📦' },
 ]


### PR DESCRIPTION
## Summary

Four issues addressed in this PR, all stemming from the latest review session.

---

### #54 — Fix: Equipment category filter returns no results

The category filter dropdown included an option labeled **"Equipment"** (mapped to `category = equipment`) that visually collided with the `type = Equipment` field. Users selecting "Equipment" in the filter expected to see all Equipment-type materials, but got nothing because their materials have `type = Equipment` with categories like `reagent` or `glassware`.

**Fix:** Renamed the `category = equipment` label to **"Instruments"** everywhere — `Materials.tsx`, all three preview pages, and `MaterialForm.tsx`.

---

### #55 — Fix: Profile form fields blank on page load

`Profile.tsx` was calling `api.get<UserProfile>("/api/users/me")` but the actual response shape is `{ status: "ok", data: UserProfile }`. The page typed it as `UserProfile` directly, so `p.displayName` etc. were all `undefined` and all fields appeared empty.

**Fix:** Changed the type annotation to `ApiResponse<UserProfile>` and destructured `.data`. Applied the same fix to the `api.patch` response for saving.

---

### #56 — Feature: User role and is_admin fields

**Backend (`backend/src/types/user.ts`, `userController.ts`)**
- Added `role: UserRole | null` and `is_admin: boolean` to `UserProfile` and `UserProfileResponse`
- `role` added to `UpdateUserBody`; `is_admin` intentionally absent (not user-settable)
- `upsertMe` initialises both on new accounts; backfills them for existing accounts on next sign-in
- `updateMe` validates `role` against the enum list and persists it

**Role values:** `citizen_scientist` · `student` · `teacher` · `professional_researcher` · `industry_professional` · `hobbyist` · `other`

**Frontend (`Profile.tsx`)**
- Role dropdown pre-populated from the database
- Admin badge (`admin` pill in burnt sienna) shown when `is_admin === true`
- All form fields now correctly pre-populate from the database on load

---

### #57 — Design: Finalize Materials page (Materials 3 direction)

- **Global warm background:** `body` now uses `var(--color-surface)` (`#F5EAE0`) instead of gray-50
- **Materials.tsx** replaced with the Materials 3 aesthetic plus the requested layout changes:
  - Big Fraunces title with cheeky subtitle
  - Bold dark-indigo / burnt-sienna section hero banners with SVG icons
  - Side-by-side Equipment / Consumables grid on `lg+`; stacked on mobile
  - Mobile jump links ("↓ Equipment" / "↓ Consumables") below the filter bar
  - `#hashtag` DM Mono tag chips, `rounded-2xl` cards, plum hover borders
  - Category filter renamed "Instruments" in preview pages too

---

## Test plan

- [ ] Select "Instruments" in the category filter — verify it filters by `category = equipment`; selecting any other filter should also work
- [ ] Navigate to Profile — confirm display name, affiliation, bio, and role are pre-populated
- [ ] Update role via dropdown and save — confirm it persists
- [ ] Sign out and back in — confirm `is_admin` and `role` are preserved
- [ ] Main Materials page shows side-by-side Equipment / Consumables on a wide screen, stacked on mobile
- [ ] Jump links on mobile scroll to the correct section
- [ ] Site-wide background uses the warm linen colour
- [ ] `npm run build` passes

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15