### PR TITLE
My Lab, Admin Panel, reusable MaterialCard + detail modal

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,7 @@ import healthRouter from './routes/health'
 import usersRouter from './routes/users'
 import designsRouter from './routes/designs'
 import materialsRouter from './routes/materials'
+import labRouter from './routes/lab'
 
 const app = express()
 
@@ -36,6 +37,7 @@ app.use('/api/health', healthRouter)
 app.use('/api/users', usersRouter)
 app.use('/api/designs', designsRouter)
 app.use('/api/materials', materialsRouter)
+app.use('/api/lab', labRouter)
 
 // Error handling (must be last)
 app.use(notFound)

--- a/backend/src/controllers/labController.ts
+++ b/backend/src/controllers/labController.ts
@@ -1,0 +1,96 @@
+import { Request, Response, NextFunction } from 'express'
+import { FieldValue } from 'firebase-admin/firestore'
+import { adminDb } from '../lib/firebase'
+import { Material, MaterialResponse } from '../types/material'
+import { AppError } from '../middleware/errorHandler'
+
+const LAB = 'lab'
+const MATERIALS = 'materials'
+
+function toResponse(m: Material): MaterialResponse {
+  return {
+    ...m,
+    created_at: m.created_at.toDate().toISOString(),
+    updated_at: m.updated_at.toDate().toISOString(),
+  }
+}
+
+function notFound(msg = 'Material not found'): AppError {
+  const err: AppError = new Error(msg)
+  err.statusCode = 404
+  return err
+}
+
+// ─── GET /api/lab ─────────────────────────────────────────────────────────────
+// Returns all materials in the current user's lab, as full material objects.
+export async function getLab(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const uid = req.user!.uid
+    const labSnap = await adminDb.collection('users').doc(uid).collection(LAB).get()
+
+    if (labSnap.empty) {
+      res.status(200).json({ status: 'ok', data: [] })
+      return
+    }
+
+    const materialIds = labSnap.docs.map((d) => d.id)
+    const materialSnaps = await Promise.all(
+      materialIds.map((id) => adminDb.collection(MATERIALS).doc(id).get()),
+    )
+
+    const data: MaterialResponse[] = materialSnaps
+      .filter((snap) => snap.exists)
+      .map((snap) => toResponse(snap.data() as Material))
+
+    res.status(200).json({ status: 'ok', data })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── POST /api/lab/:materialId ────────────────────────────────────────────────
+// Adds a material to the current user's lab.
+export async function addToLab(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const uid = req.user!.uid
+    const { materialId } = req.params
+
+    const matSnap = await adminDb.collection(MATERIALS).doc(materialId).get()
+    if (!matSnap.exists) return next(notFound())
+
+    await adminDb.collection('users').doc(uid).collection(LAB).doc(materialId).set({
+      material_id: materialId,
+      added_at: FieldValue.serverTimestamp(),
+    })
+
+    res.status(201).json({ status: 'ok' })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── DELETE /api/lab/:materialId ──────────────────────────────────────────────
+// Removes a material from the current user's lab.
+export async function removeFromLab(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const uid = req.user!.uid
+    const { materialId } = req.params
+
+    await adminDb.collection('users').doc(uid).collection(LAB).doc(materialId).delete()
+    res.status(200).json({ status: 'ok' })
+  } catch (err) {
+    next(err)
+  }
+}

--- a/backend/src/routes/lab.ts
+++ b/backend/src/routes/lab.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express'
+import { requireAuth } from '../middleware/auth'
+import { getLab, addToLab, removeFromLab } from '../controllers/labController'
+
+const router = Router()
+
+router.use(requireAuth)
+
+router.get('/', getLab)
+router.post('/:materialId', addToLab)
+router.delete('/:materialId', removeFromLab)
+
+export default router

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,11 +6,11 @@ import Experiments from './pages/Experiments'
 import NotFound from './pages/NotFound'
 import Profile from './pages/Profile'
 import MyDesigns from './pages/MyDesigns'
+import MyLab from './pages/MyLab'
 import CreateDesign from './pages/CreateDesign'
 import EditDesign from './pages/EditDesign'
 import DesignDetail from './pages/DesignDetail'
 import Materials from './pages/Materials'
-import MaterialDetail from './pages/MaterialDetail'
 import CreateMaterial from './pages/CreateMaterial'
 
 export default function App() {
@@ -21,15 +21,16 @@ export default function App() {
         <Route index element={<Home />} />
         <Route path="experiments" element={<Experiments />} />
         <Route path="designs/:id" element={<DesignDetail />} />
-        <Route path="materials" element={<Materials />} />
-        <Route path="materials/:id" element={<MaterialDetail />} />
 
-        {/* Protected */}
+        {/* Protected (logged-in users) */}
         <Route element={<PrivateRoute />}>
           <Route path="profile" element={<Profile />} />
+          <Route path="my-lab" element={<MyLab />} />
           <Route path="designs/mine" element={<MyDesigns />} />
           <Route path="designs/new" element={<CreateDesign />} />
           <Route path="designs/:id/edit" element={<EditDesign />} />
+          {/* Admin-only — access guard is in the Materials component */}
+          <Route path="materials" element={<Materials />} />
           <Route path="materials/new" element={<CreateMaterial />} />
         </Route>
 

--- a/frontend/src/components/MaterialCard.tsx
+++ b/frontend/src/components/MaterialCard.tsx
@@ -1,0 +1,116 @@
+/**
+ * MaterialCard — compact, reusable card for displaying a material.
+ *
+ * Clicking the main card body calls onDetails(material) to open the detail modal.
+ * When onAdd/onRemove props are provided, an action icon appears on the right that
+ * lets users add/remove the material from their lab without leaving the current page.
+ */
+import type { Material, MaterialCategory } from '../types/material'
+
+const CATEGORY_META: Record<MaterialCategory, { label: string; emoji: string }> = {
+  glassware:  { label: 'Glassware',   emoji: '🫙' },
+  reagent:    { label: 'Reagent',     emoji: '⚗️' },
+  equipment:  { label: 'Instruments', emoji: '🔬' },
+  biological: { label: 'Biological',  emoji: '🧬' },
+  other:      { label: 'Other',       emoji: '📦' },
+}
+
+interface MaterialCardProps {
+  material: Material
+  onDetails: (m: Material) => void
+  /** Whether this material is already in the user's lab */
+  inLab?: boolean
+  /** Called when the user clicks the add icon. Omit to hide the action icon. */
+  onAdd?: (m: Material) => void
+  /** Called when the user clicks the remove icon. Omit to hide the action icon. */
+  onRemove?: (m: Material) => void
+  /** Disables the action icon while an add/remove is in progress */
+  actionPending?: boolean
+}
+
+export default function MaterialCard({
+  material,
+  onDetails,
+  inLab = false,
+  onAdd,
+  onRemove,
+  actionPending = false,
+}: MaterialCardProps) {
+  const cat = CATEGORY_META[material.category]
+  const showAction = !!(onAdd || onRemove)
+
+  function handleAction(e: React.MouseEvent) {
+    e.stopPropagation()
+    if (actionPending) return
+    if (inLab) {
+      onRemove?.(material)
+    } else {
+      onAdd?.(material)
+    }
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onDetails(material)}
+      onKeyDown={(e) => e.key === 'Enter' && onDetails(material)}
+      className="group cursor-pointer bg-white rounded-xl border-2 border-surface-2
+                 px-4 py-3 hover:border-plum hover:shadow-sm transition-all
+                 flex items-center gap-3 text-left w-full"
+    >
+      {/* Main content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 mb-0.5">
+          <span className="text-xs text-muted">
+            {cat?.emoji} {cat?.label}
+          </span>
+          {material.is_verified && (
+            <span className="text-xs text-emerald-600 font-medium">✓</span>
+          )}
+        </div>
+        <p className="font-medium text-ink text-sm leading-snug group-hover:text-primary
+                      transition-colors truncate">
+          {material.name}
+        </p>
+        {(material.supplier || material.typical_cost_usd != null) && (
+          <p className="text-xs text-muted mt-0.5 truncate">
+            {material.supplier}
+            {material.supplier && material.typical_cost_usd != null && ' · '}
+            {material.typical_cost_usd != null && `$${material.typical_cost_usd.toFixed(2)}`}
+          </p>
+        )}
+      </div>
+
+      {/* Lab action icon */}
+      {showAction && (
+        <button
+          type="button"
+          onClick={handleAction}
+          disabled={actionPending}
+          title={inLab ? 'Remove from lab' : 'Add to lab'}
+          className={`shrink-0 w-8 h-8 rounded-lg flex items-center justify-center
+                      transition-all disabled:opacity-40 disabled:cursor-not-allowed ${
+            inLab
+              ? 'text-red-400 hover:bg-red-50 hover:text-red-600'
+              : 'text-primary hover:bg-primary/10'
+          }`}
+        >
+          {actionPending ? (
+            <div className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+          ) : inLab ? (
+            /* Minus / remove */
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M20 12H4" />
+            </svg>
+          ) : (
+            /* Plus / add */
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+            </svg>
+          )}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/MaterialDetailModal.tsx
+++ b/frontend/src/components/MaterialDetailModal.tsx
@@ -1,0 +1,224 @@
+/**
+ * MaterialDetailModal — shows full material details in an overlay modal.
+ * Replaces navigation to /materials/:id so users stay on the current page.
+ */
+import { useEffect } from 'react'
+import type { Material } from '../types/material'
+
+interface Props {
+  material: Material
+  onClose: () => void
+  /** Optional: show an add/remove lab button in the modal header */
+  inLab?: boolean
+  onAdd?: (m: Material) => void
+  onRemove?: (m: Material) => void
+  actionPending?: boolean
+}
+
+export default function MaterialDetailModal({
+  material,
+  onClose,
+  inLab,
+  onAdd,
+  onRemove,
+  actionPending,
+}: Props) {
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  // Prevent body scroll while modal is open
+  useEffect(() => {
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = '' }
+  }, [])
+
+  const showLabAction = !!(onAdd || onRemove)
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0,0,0,0.45)' }}
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-2xl w-full max-w-lg max-h-[88vh] overflow-y-auto
+                   shadow-xl flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-0">
+          <div className="flex-1 min-w-0">
+            {/* Badges */}
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              <span
+                className="text-xs font-medium px-2.5 py-1 rounded-full"
+                style={{ background: 'var(--color-blush)', color: 'var(--color-plum)' }}
+              >
+                {material.type}
+              </span>
+              <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-gray-100 text-gray-600 capitalize">
+                {material.category}
+              </span>
+              {material.is_verified && (
+                <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-emerald-50 text-emerald-700">
+                  ✓ Verified
+                </span>
+              )}
+            </div>
+            <h2
+              className="text-xl font-semibold text-ink leading-tight"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              {material.name}
+            </h2>
+          </div>
+
+          <div className="flex items-center gap-2 shrink-0">
+            {/* Lab action */}
+            {showLabAction && (
+              <button
+                type="button"
+                onClick={() => { inLab ? onRemove?.(material) : onAdd?.(material) }}
+                disabled={actionPending}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium
+                            border-2 transition-all disabled:opacity-50 ${
+                  inLab
+                    ? 'border-red-200 text-red-500 hover:bg-red-50'
+                    : 'border-primary/30 text-primary hover:bg-primary/10'
+                }`}
+              >
+                {actionPending ? (
+                  <div className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                ) : inLab ? (
+                  <>
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M20 12H4" />
+                    </svg>
+                    Remove
+                  </>
+                ) : (
+                  <>
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+                    </svg>
+                    Add to lab
+                  </>
+                )}
+              </button>
+            )}
+
+            {/* Close */}
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-8 h-8 rounded-lg flex items-center justify-center text-muted
+                         hover:bg-gray-100 hover:text-ink transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 pb-6 pt-4 space-y-4">
+          {/* Image */}
+          {material.image_url && (
+            <img
+              src={material.image_url}
+              alt={material.name}
+              className="w-full max-h-52 object-contain rounded-xl border border-gray-200 bg-gray-50"
+            />
+          )}
+
+          {/* Description */}
+          {material.description && (
+            <section>
+              <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-1.5">
+                Description
+              </h3>
+              <p className="text-sm text-ink leading-relaxed">{material.description}</p>
+            </section>
+          )}
+
+          {/* Details */}
+          {(material.supplier || material.typical_cost_usd != null || material.link) && (
+            <section>
+              <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+                Details
+              </h3>
+              <dl className="space-y-1.5 text-sm">
+                {material.supplier && (
+                  <div className="flex gap-2">
+                    <dt className="w-28 shrink-0 text-muted">Supplier</dt>
+                    <dd className="text-ink">{material.supplier}</dd>
+                  </div>
+                )}
+                {material.typical_cost_usd != null && (
+                  <div className="flex gap-2">
+                    <dt className="w-28 shrink-0 text-muted">Typical cost</dt>
+                    <dd className="text-ink">${material.typical_cost_usd.toFixed(2)}</dd>
+                  </div>
+                )}
+                {material.link && (
+                  <div className="flex gap-2">
+                    <dt className="w-28 shrink-0 text-muted">Product link</dt>
+                    <dd>
+                      <a
+                        href={material.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline break-all"
+                      >
+                        {material.link}
+                      </a>
+                    </dd>
+                  </div>
+                )}
+              </dl>
+            </section>
+          )}
+
+          {/* Safety notes */}
+          {material.safety_notes && (
+            <section className="bg-amber-50 rounded-xl p-4">
+              <h3 className="text-xs font-semibold text-amber-700 uppercase tracking-wide mb-1.5">
+                ⚠ Safety Notes
+              </h3>
+              <p className="text-sm text-amber-900 whitespace-pre-line">{material.safety_notes}</p>
+            </section>
+          )}
+
+          {/* Tags */}
+          {material.tags.length > 0 && (
+            <section>
+              <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">Tags</h3>
+              <div className="flex flex-wrap gap-1.5">
+                {material.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="text-xs px-2.5 py-1 rounded-lg font-medium"
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      background: 'var(--color-blush)',
+                      color: 'var(--color-plum)',
+                    }}
+                  >
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/MaterialsDrawer.tsx
+++ b/frontend/src/components/MaterialsDrawer.tsx
@@ -1,0 +1,265 @@
+/**
+ * MaterialsDrawer — slides in from the right, showing all system materials.
+ * Users can search, filter by category, and add/remove materials from their lab.
+ */
+import { useEffect, useMemo, useState } from 'react'
+import { api } from '../lib/api'
+import type { Material, MaterialCategory, MaterialListResponse } from '../types/material'
+import MaterialCard from './MaterialCard'
+import MaterialDetailModal from './MaterialDetailModal'
+
+const CATEGORIES: { value: MaterialCategory; label: string; emoji: string }[] = [
+  { value: 'glassware',  label: 'Glassware',   emoji: '🫙' },
+  { value: 'reagent',    label: 'Reagent',     emoji: '⚗️' },
+  { value: 'equipment',  label: 'Instruments', emoji: '🔬' },
+  { value: 'biological', label: 'Biological',  emoji: '🧬' },
+  { value: 'other',      label: 'Other',       emoji: '📦' },
+]
+
+interface Props {
+  /** Set of material IDs currently in the user's lab */
+  labIds: Set<string>
+  /** Set of material IDs with a pending add/remove in flight */
+  pendingIds: Set<string>
+  onAdd: (material: Material) => void
+  onRemove: (material: Material) => void
+  onClose: () => void
+}
+
+export default function MaterialsDrawer({ labIds, pendingIds, onAdd, onRemove, onClose }: Props) {
+  const [equipmentAll, setEquipmentAll] = useState<Material[]>([])
+  const [consumablesAll, setConsumablesAll] = useState<Material[]>([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [category, setCategory] = useState<MaterialCategory | ''>('')
+  const [selectedMaterial, setSelectedMaterial] = useState<Material | null>(null)
+
+  // Load all materials once on mount
+  useEffect(() => {
+    Promise.all([
+      api.get<MaterialListResponse>('/api/materials?type=Equipment&limit=100'),
+      api.get<MaterialListResponse>('/api/materials?type=Consumable&limit=100'),
+    ])
+      .then(([eq, con]) => {
+        setEquipmentAll(eq.data)
+        setConsumablesAll(con.data)
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !selectedMaterial) onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose, selectedMaterial])
+
+  // Client-side search (name, description, tags) + category filter
+  function matches(m: Material): boolean {
+    if (category && m.category !== category) return false
+    if (!search.trim()) return true
+    const q = search.toLowerCase()
+    return (
+      m.name.toLowerCase().includes(q) ||
+      (m.description?.toLowerCase().includes(q) ?? false) ||
+      m.tags.some((t) => t.toLowerCase().includes(q))
+    )
+  }
+
+  const filteredEquipment  = useMemo(() => equipmentAll.filter(matches),  [equipmentAll,  search, category])  // eslint-disable-line react-hooks/exhaustive-deps
+  const filteredConsumables = useMemo(() => consumablesAll.filter(matches), [consumablesAll, search, category])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  const totalShown = filteredEquipment.length + filteredConsumables.length
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/30"
+        onClick={onClose}
+      />
+
+      {/* Drawer panel */}
+      <div
+        className="fixed right-0 top-0 h-full w-full max-w-md z-40
+                   bg-white shadow-2xl flex flex-col"
+        style={{ background: 'var(--color-surface)' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-surface-2 bg-white">
+          <div>
+            <h2
+              className="text-lg font-semibold text-ink"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              Add Materials
+            </h2>
+            <p className="text-xs text-muted mt-0.5">
+              Browse and add materials to your lab
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-muted
+                       hover:bg-gray-100 hover:text-ink transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="px-5 pt-4 pb-3 border-b border-surface-2 bg-white space-y-3">
+          <div className="relative">
+            <svg
+              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />
+            </svg>
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by name, description, or tag…"
+              className="w-full pl-9 pr-4 py-2 text-sm rounded-xl border-2 border-surface-2
+                         focus:border-plum focus:outline-none bg-white"
+            />
+          </div>
+
+          {/* Category pills */}
+          <div className="flex flex-wrap gap-1.5">
+            <CategoryPill label="All" active={category === ''} onClick={() => setCategory('')} />
+            {CATEGORIES.map((c) => (
+              <CategoryPill
+                key={c.value}
+                label={`${c.emoji} ${c.label}`}
+                active={category === c.value}
+                onClick={() => setCategory(category === c.value ? '' : c.value)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Results */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <div className="w-6 h-6 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+            </div>
+          ) : totalShown === 0 ? (
+            <div className="text-center py-12 text-muted text-sm">
+              {search ? 'No materials match your search.' : 'No materials found.'}
+            </div>
+          ) : (
+            <>
+              {filteredEquipment.length > 0 && (
+                <MaterialSection
+                  title="Equipment"
+                  materials={filteredEquipment}
+                  labIds={labIds}
+                  pendingIds={pendingIds}
+                  onAdd={onAdd}
+                  onRemove={onRemove}
+                  onDetails={setSelectedMaterial}
+                />
+              )}
+              {filteredConsumables.length > 0 && (
+                <MaterialSection
+                  title="Consumables"
+                  materials={filteredConsumables}
+                  labIds={labIds}
+                  pendingIds={pendingIds}
+                  onAdd={onAdd}
+                  onRemove={onRemove}
+                  onDetails={setSelectedMaterial}
+                />
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Detail modal (above drawer) */}
+      {selectedMaterial && (
+        <MaterialDetailModal
+          material={selectedMaterial}
+          onClose={() => setSelectedMaterial(null)}
+          inLab={labIds.has(selectedMaterial.id)}
+          onAdd={onAdd}
+          onRemove={onRemove}
+          actionPending={pendingIds.has(selectedMaterial.id)}
+        />
+      )}
+    </>
+  )
+}
+
+function MaterialSection({
+  title,
+  materials,
+  labIds,
+  pendingIds,
+  onAdd,
+  onRemove,
+  onDetails,
+}: {
+  title: string
+  materials: Material[]
+  labIds: Set<string>
+  pendingIds: Set<string>
+  onAdd: (m: Material) => void
+  onRemove: (m: Material) => void
+  onDetails: (m: Material) => void
+}) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+        {title} · {materials.length}
+      </h3>
+      <div className="space-y-2">
+        {materials.map((m) => (
+          <MaterialCard
+            key={m.id}
+            material={m}
+            onDetails={onDetails}
+            inLab={labIds.has(m.id)}
+            onAdd={onAdd}
+            onRemove={onRemove}
+            actionPending={pendingIds.has(m.id)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function CategoryPill({
+  label,
+  active,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1 px-3 py-1 rounded-lg text-xs font-medium
+                  border transition-all ${
+        active
+          ? 'border-ink bg-ink text-white'
+          : 'border-surface-2 bg-white text-ink hover:border-plum'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -5,17 +5,35 @@ import { useAuth } from '../contexts/AuthContext'
 const publicNavLinks = [
   { to: '/', label: 'Home', end: true },
   { to: '/experiments', label: 'Experiments', end: false },
+]
+
+const adminNavLinks = [
   { to: '/materials', label: 'Materials', end: true },
 ]
 
 export default function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false)
-  const { user, loading, signIn, signOut } = useAuth()
+  const [adminOpen, setAdminOpen] = useState(false)
+  const { user, isAdmin, loading, signIn, signOut } = useAuth()
 
-  const navLinks = [
-    ...publicNavLinks,
-    ...(user ? [{ to: '/designs/mine', label: 'My Designs', end: false }] : []),
-  ]
+  const userNavLinks = user
+    ? [
+        { to: '/my-lab', label: 'My Lab', end: false },
+        { to: '/designs/mine', label: 'My Designs', end: false },
+      ]
+    : []
+
+  const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+      isActive
+        ? 'bg-surface text-primary'
+        : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+    }`
+
+  const mobileNavLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+      isActive ? 'bg-surface text-primary' : 'text-gray-600 hover:bg-gray-100'
+    }`
 
   const authButtons = loading ? null : user ? (
     <>
@@ -68,23 +86,58 @@ export default function Navbar() {
 
           {/* Desktop nav */}
           <nav className="hidden md:flex items-center gap-1">
-            {navLinks.map(({ to, label, end }) => (
-              <NavLink
-                key={to}
-                to={to}
-                end={end}
-                className={({ isActive }) =>
-                  `px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    isActive
-                      ? 'bg-surface text-primary'
-                      : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-                  }`
-                }
-              >
+            {publicNavLinks.map(({ to, label, end }) => (
+              <NavLink key={to} to={to} end={end} className={navLinkClass}>
                 {label}
               </NavLink>
             ))}
 
+            {userNavLinks.map(({ to, label, end }) => (
+              <NavLink key={to} to={to} end={end} className={navLinkClass}>
+                {label}
+              </NavLink>
+            ))}
+
+            {/* Admin Panel dropdown — admin-only */}
+            {isAdmin && (
+              <div className="relative">
+                <button
+                  onClick={() => setAdminOpen((v) => !v)}
+                  onBlur={() => setTimeout(() => setAdminOpen(false), 150)}
+                  className="flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium
+                             text-gray-600 hover:bg-gray-100 hover:text-gray-900 transition-colors"
+                >
+                  Admin Panel
+                  <svg
+                    className={`w-3.5 h-3.5 transition-transform ${adminOpen ? 'rotate-180' : ''}`}
+                    fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+                {adminOpen && (
+                  <div className="absolute left-0 top-full mt-1 w-48 bg-white rounded-xl shadow-lg
+                                  border border-gray-200 py-1 z-50">
+                    {adminNavLinks.map(({ to, label }) => (
+                      <NavLink
+                        key={to}
+                        to={to}
+                        onClick={() => setAdminOpen(false)}
+                        className={({ isActive }) =>
+                          `block px-4 py-2 text-sm transition-colors ${
+                            isActive
+                              ? 'bg-surface text-primary font-medium'
+                              : 'text-gray-700 hover:bg-gray-50'
+                          }`
+                        }
+                      >
+                        {label}
+                      </NavLink>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </nav>
 
           {/* Desktop CTA */}
@@ -113,23 +166,28 @@ export default function Navbar() {
         {/* Mobile menu */}
         {mobileOpen && (
           <div className="md:hidden pb-4 space-y-1">
-            {navLinks.map(({ to, label, end }) => (
-              <NavLink
-                key={to}
-                to={to}
-                end={end}
-                onClick={() => setMobileOpen(false)}
-                className={({ isActive }) =>
-                  `block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    isActive
-                      ? 'bg-surface text-primary'
-                      : 'text-gray-600 hover:bg-gray-100'
-                  }`
-                }
-              >
+            {publicNavLinks.map(({ to, label, end }) => (
+              <NavLink key={to} to={to} end={end} onClick={() => setMobileOpen(false)} className={mobileNavLinkClass}>
                 {label}
               </NavLink>
             ))}
+            {userNavLinks.map(({ to, label, end }) => (
+              <NavLink key={to} to={to} end={end} onClick={() => setMobileOpen(false)} className={mobileNavLinkClass}>
+                {label}
+              </NavLink>
+            ))}
+            {isAdmin && (
+              <>
+                <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wide">
+                  Admin Panel
+                </p>
+                {adminNavLinks.map(({ to, label }) => (
+                  <NavLink key={to} to={to} onClick={() => setMobileOpen(false)} className={mobileNavLinkClass}>
+                    {label}
+                  </NavLink>
+                ))}
+              </>
+            )}
             <div className="pt-2 flex flex-col gap-2">
               {mobileAuthButtons}
             </div>

--- a/frontend/src/pages/MyLab.tsx
+++ b/frontend/src/pages/MyLab.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useState } from 'react'
+import { api } from '../lib/api'
+import type { Material } from '../types/material'
+import MaterialCard from '../components/MaterialCard'
+import MaterialDetailModal from '../components/MaterialDetailModal'
+import MaterialsDrawer from '../components/MaterialsDrawer'
+
+export default function MyLab() {
+  const [labMaterials, setLabMaterials] = useState<Material[]>([])
+  const [loading, setLoading] = useState(true)
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set())
+  const [showDrawer, setShowDrawer] = useState(false)
+  const [selectedMaterial, setSelectedMaterial] = useState<Material | null>(null)
+
+  const labIds = useMemo(() => new Set(labMaterials.map((m) => m.id)), [labMaterials])
+  const equipment   = labMaterials.filter((m) => m.type === 'Equipment')
+  const consumables = labMaterials.filter((m) => m.type === 'Consumable')
+
+  async function fetchLab() {
+    try {
+      const res = await api.get<{ status: string; data: Material[] }>('/api/lab')
+      setLabMaterials(res.data)
+    } catch {
+      // keep empty
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchLab() }, [])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  function setPending(id: string, on: boolean) {
+    setPendingIds((prev) => {
+      const next = new Set(prev)
+      on ? next.add(id) : next.delete(id)
+      return next
+    })
+  }
+
+  async function handleAdd(material: Material) {
+    if (pendingIds.has(material.id)) return
+    setPending(material.id, true)
+    try {
+      await api.post(`/api/lab/${material.id}`)
+      setLabMaterials((prev) => [...prev, material])
+    } finally {
+      setPending(material.id, false)
+    }
+  }
+
+  async function handleRemove(material: Material) {
+    if (pendingIds.has(material.id)) return
+    setPending(material.id, true)
+    try {
+      await api.delete(`/api/lab/${material.id}`)
+      setLabMaterials((prev) => prev.filter((m) => m.id !== material.id))
+      if (selectedMaterial?.id === material.id) setSelectedMaterial(null)
+    } finally {
+      setPending(material.id, false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--color-surface)' }}>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+
+        {/* Page header */}
+        <div className="flex flex-wrap items-end justify-between gap-4 mb-8">
+          <div>
+            <h1
+              className="text-5xl sm:text-6xl text-ink"
+              style={{ fontFamily: 'var(--font-display)' }}
+            >
+              My Lab
+            </h1>
+            <p className="mt-2 text-lg text-plum">
+              Materials you use.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowDrawer(true)}
+            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold
+                       text-white hover:opacity-90 transition-all active:scale-95"
+            style={{ background: 'var(--color-primary)' }}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+            </svg>
+            Add Materials
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="flex justify-center py-24">
+            <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : labMaterials.length === 0 ? (
+          <EmptyLab onAdd={() => setShowDrawer(true)} />
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <LabSection
+              title="Equipment"
+              emoji="🔬"
+              materials={equipment}
+              labIds={labIds}
+              pendingIds={pendingIds}
+              onRemove={handleRemove}
+              onDetails={setSelectedMaterial}
+              emptyMsg="No equipment in your lab yet."
+            />
+            <LabSection
+              title="Consumables"
+              emoji="🧪"
+              materials={consumables}
+              labIds={labIds}
+              pendingIds={pendingIds}
+              onRemove={handleRemove}
+              onDetails={setSelectedMaterial}
+              emptyMsg="No consumables in your lab yet."
+            />
+          </div>
+        )}
+      </div>
+
+      {showDrawer && (
+        <MaterialsDrawer
+          labIds={labIds}
+          pendingIds={pendingIds}
+          onAdd={handleAdd}
+          onRemove={handleRemove}
+          onClose={() => setShowDrawer(false)}
+        />
+      )}
+
+      {selectedMaterial && (
+        <MaterialDetailModal
+          material={selectedMaterial}
+          onClose={() => setSelectedMaterial(null)}
+          inLab={labIds.has(selectedMaterial.id)}
+          onAdd={handleAdd}
+          onRemove={handleRemove}
+          actionPending={pendingIds.has(selectedMaterial.id)}
+        />
+      )}
+    </div>
+  )
+}
+
+function LabSection({
+  title,
+  emoji,
+  materials,
+  labIds,
+  pendingIds,
+  onRemove,
+  onDetails,
+  emptyMsg,
+}: {
+  title: string
+  emoji: string
+  materials: Material[]
+  labIds: Set<string>
+  pendingIds: Set<string>
+  onRemove: (m: Material) => void
+  onDetails: (m: Material) => void
+  emptyMsg: string
+}) {
+  return (
+    <div>
+      {/* Section header */}
+      <div
+        className="flex items-center justify-between px-5 py-3.5 rounded-2xl mb-3"
+        style={{ background: title === 'Equipment' ? 'var(--color-dark)' : 'var(--color-primary)' }}
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-xl">{emoji}</span>
+          <h2
+            className="text-lg font-semibold text-white"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            {title}
+          </h2>
+        </div>
+        <span className="text-white/50 text-sm font-medium" style={{ fontFamily: 'var(--font-mono)' }}>
+          {materials.length}
+        </span>
+      </div>
+
+      {materials.length === 0 ? (
+        <p className="text-sm text-muted text-center py-6">{emptyMsg}</p>
+      ) : (
+        <div className="space-y-2">
+          {materials.map((m) => (
+            <MaterialCard
+              key={m.id}
+              material={m}
+              onDetails={onDetails}
+              inLab={labIds.has(m.id)}
+              onRemove={onRemove}
+              actionPending={pendingIds.has(m.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EmptyLab({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="text-center py-20">
+      <div className="text-6xl mb-4">🧫</div>
+      <h2
+        className="text-2xl text-ink mb-2"
+        style={{ fontFamily: 'var(--font-display)' }}
+      >
+        Your lab is empty
+      </h2>
+      <p className="text-muted text-sm mb-6 max-w-xs mx-auto">
+        Browse the materials catalog and add the ones you work with to your lab.
+      </p>
+      <button
+        type="button"
+        onClick={onAdd}
+        className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold
+                   text-white hover:opacity-90 transition-all"
+        style={{ background: 'var(--color-primary)' }}
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+        </svg>
+        Add Materials
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #62, #63, #64

## What's in this PR

### Backend
- **Lab API** (`/api/lab`): `GET` returns the user's lab as full `Material[]`; `POST /:materialId` adds; `DELETE /:materialId` removes. Stored in `users/{uid}/lab/{materialId}` Firestore subcollection.

### AuthContext
- Fetch `GET /api/users/me` in `onAuthStateChanged` to populate `isAdmin: boolean`. `loading` now waits for the profile fetch so the nav never flashes wrong state.

### Reusable components (closes #64)
- **MaterialCard** — compact card (name, category emoji, supplier/cost; no tags). Clicking opens the detail modal. Optional add/remove icon for lab management.
- **MaterialDetailModal** — full material detail in an overlay. Escape/backdrop closes it. Optional "Add to lab" / "Remove" button in the header.
- **MaterialsDrawer** — slides in from right. Loads all materials on open. Search box filters by name, description, and tags client-side. Category pills for type filtering.

### My Lab (closes #63)
- New /my-lab protected route. Shows user lab split into Equipment / Consumables sections.
- "Add Materials" button opens the drawer. Adding/removing updates local state immediately.
- Friendly empty state with CTA.

### Admin Panel (closes #62)
- Navbar: Materials removed from public nav. "Admin Panel" dropdown appears only when isAdmin === true. "My Lab" link added for all logged-in users.
- Materials page: Admin guard redirects non-admins to /. Shows "Admin Panel" breadcrumb. Uses MaterialCard + MaterialDetailModal instead of page navigation on card click.
- /materials moved to protected routes; /materials/:id removed (detail is now in modal).

## Test plan

- [ ] Sign in as regular user: no Admin Panel in nav, My Lab visible, /materials redirects to /
- [ ] Sign in as admin: Admin Panel dropdown visible, /materials loads
- [ ] My Lab: Add Materials opens drawer with search + filters + add/remove icons
- [ ] Add a material: appears in My Lab, drawer icon switches to remove
- [ ] Click any material card: detail modal opens without navigation
- [ ] Modal closes on Escape, backdrop click, or X

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15