### PR TITLE
Dev: admin self-promotion toggle in Profile (closes #66)

### DIFF
--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -109,7 +109,7 @@ export async function updateMe(
       return next(error)
     }
 
-    const { displayName, photoURL, bio, affiliation, role }: UpdateUserBody = req.body
+    const { displayName, photoURL, bio, affiliation, role, is_admin }: UpdateUserBody = req.body
     const validRoles = USER_ROLES.map(r => r.value) as string[]
     if (role !== undefined && role !== null && !validRoles.includes(role)) {
       const error: AppError = new Error(`role must be one of: ${validRoles.join(', ')}`)
@@ -122,6 +122,7 @@ export async function updateMe(
     if (bio !== undefined) patch.bio = bio
     if (affiliation !== undefined) patch.affiliation = affiliation
     if (role !== undefined) patch.role = role
+    if (is_admin !== undefined) patch.is_admin = is_admin
 
     await ref.update(patch)
     const updated = await ref.get()

--- a/backend/src/types/user.ts
+++ b/backend/src/types/user.ts
@@ -52,5 +52,6 @@ export interface UpdateUserBody {
   bio?: string | null
   affiliation?: string | null
   role?: UserRole | null
-  // is_admin is intentionally excluded — not user-settable
+  /** Dev-only self-promotion toggle — remove before production hardening */
+  is_admin?: boolean
 }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -15,6 +15,8 @@ interface AuthContextValue {
   loading: boolean
   signIn: () => Promise<void>
   signOut: () => Promise<void>
+  /** Re-fetches the user profile and updates isAdmin. Call after toggling admin status. */
+  refreshIsAdmin: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -55,12 +57,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }
 
+  async function refreshIsAdmin() {
+    try {
+      const res = await api.get<{ status: string; data: { is_admin: boolean } }>('/api/users/me')
+      setIsAdmin(res.data.is_admin ?? false)
+    } catch {
+      // ignore
+    }
+  }
+
   async function signOut() {
     await firebaseSignOut(auth)
   }
 
   return (
-    <AuthContext.Provider value={{ user, isAdmin, loading, signIn, signOut }}>
+    <AuthContext.Provider value={{ user, isAdmin, loading, signIn, signOut, refreshIsAdmin }}>
       {children}
     </AuthContext.Provider>
   )

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -38,13 +38,14 @@ interface ApiResponse<T> {
 }
 
 export default function Profile() {
-  const { user } = useAuth()
+  const { user, isAdmin, refreshIsAdmin } = useAuth()
   const [profile, setProfile] = useState<UserProfile | null>(null)
   const [displayName, setDisplayName] = useState('')
   const [bio, setBio] = useState('')
   const [affiliation, setAffiliation] = useState('')
   const [role, setRole] = useState<UserRole | ''>('')
   const [saving, setSaving] = useState(false)
+  const [togglingAdmin, setTogglingAdmin] = useState(false)
   const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')
   const [errorMsg, setErrorMsg] = useState('')
 
@@ -77,6 +78,16 @@ export default function Profile() {
       setErrorMsg(err instanceof Error ? err.message : 'Failed to save')
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function handleToggleAdmin() {
+    setTogglingAdmin(true)
+    try {
+      await api.patch<ApiResponse<UserProfile>>('/api/users/me', { is_admin: !isAdmin })
+      await refreshIsAdmin()
+    } finally {
+      setTogglingAdmin(false)
     }
   }
 
@@ -123,6 +134,36 @@ export default function Profile() {
             )}
           </div>
           <p className="text-sm text-muted">{profile.email}</p>
+        </div>
+      </div>
+
+      {/* ── Dev-only: self-promote to admin ── */}
+      <div className="mb-8 rounded-xl border-2 border-dashed border-amber-300 bg-amber-50 p-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold text-amber-700 uppercase tracking-wide mb-0.5">
+              Dev tool · remove before prod
+            </p>
+            <p className="text-sm text-amber-900">
+              Admin access — currently{' '}
+              <span className="font-semibold">{isAdmin ? 'enabled' : 'disabled'}</span>
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleToggleAdmin}
+            disabled={togglingAdmin}
+            className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full
+                        border-2 transition-colors duration-200 focus:outline-none
+                        disabled:opacity-50 ${
+              isAdmin ? 'border-amber-500 bg-amber-500' : 'border-gray-300 bg-gray-200'
+            }`}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow
+                          transition-transform duration-200 ${isAdmin ? 'translate-x-5' : 'translate-x-0.5'}`}
+            />
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
Closes #66

Adds a clearly-labelled dev-only toggle in the Profile page so any user can flip their own `is_admin` flag without needing direct Firestore access.

## Changes

- **`backend/src/types/user.ts`** — add optional `is_admin?: boolean` to `UpdateUserBody` (marked with a removal note)
- **`backend/src/controllers/userController.ts`** — persist `is_admin` in `PATCH /api/users/me` when supplied
- **`frontend/src/contexts/AuthContext.tsx`** — expose `refreshIsAdmin()` to re-sync the `isAdmin` state from the server without a full page reload
- **`frontend/src/pages/Profile.tsx`** — amber dashed-border section with a toggle switch; toggling calls the API then `refreshIsAdmin()` so the Admin Panel nav item appears/disappears immediately

## Removal checklist (before prod)
- [ ] Remove `is_admin` from `UpdateUserBody`
- [ ] Remove `if (is_admin !== undefined) patch.is_admin = is_admin` from `userController.ts`
- [ ] Remove the dev toggle section from `Profile.tsx`

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15