### PR TITLE
feat: Add Material via modal + admin inline edit (closes #68)

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import * as admin from 'firebase-admin'
 import { Request, Response, NextFunction } from 'express'
-import { adminAuth } from '../lib/firebase'
+import { adminAuth, adminDb } from '../lib/firebase'
 
 declare global {
   namespace Express {
@@ -27,5 +27,23 @@ export async function requireAuth(
     next()
   } catch {
     res.status(401).json({ status: 'error', message: 'Invalid or expired token' })
+  }
+}
+
+/** Must be used after requireAuth. Returns 403 if the caller is not an admin. */
+export async function requireAdmin(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const snap = await adminDb.collection('users').doc(req.user!.uid).get()
+    if (!snap.exists || snap.data()?.is_admin !== true) {
+      res.status(403).json({ status: 'error', message: 'Admin access required' })
+      return
+    }
+    next()
+  } catch {
+    res.status(403).json({ status: 'error', message: 'Admin access required' })
   }
 }

--- a/backend/src/routes/materials.ts
+++ b/backend/src/routes/materials.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
-import { requireAuth } from '../middleware/auth'
-import { listMaterials, createMaterial, getMaterial } from '../controllers/materialController'
+import { requireAuth, requireAdmin } from '../middleware/auth'
+import { listMaterials, createMaterial, getMaterial, updateMaterial } from '../controllers/materialController'
 
 const router = Router()
 
@@ -11,5 +11,8 @@ router.get('/:id', getMaterial)
 // Auth required
 router.use(requireAuth)
 router.post('/', createMaterial)
+
+// Admin required
+router.patch('/:id', requireAdmin, updateMaterial)
 
 export default router

--- a/backend/src/types/material.ts
+++ b/backend/src/types/material.ts
@@ -41,6 +41,20 @@ export interface CreateMaterialBody {
   tags?: string[]
 }
 
+export interface UpdateMaterialBody {
+  name?: string
+  type?: MaterialType
+  category?: MaterialCategory
+  description?: string | null
+  link?: string | null
+  image_url?: string | null
+  supplier?: string | null
+  typical_cost_usd?: number | null
+  safety_notes?: string | null
+  tags?: string[]
+  is_verified?: boolean
+}
+
 // ─── API response types ───────────────────────────────────────────────────────
 
 export interface MaterialResponse extends Omit<Material, 'created_at' | 'updated_at'> {

--- a/frontend/src/components/CreateMaterialModal.tsx
+++ b/frontend/src/components/CreateMaterialModal.tsx
@@ -1,0 +1,111 @@
+/**
+ * CreateMaterialModal — opens the "Submit material" form in a modal overlay
+ * instead of navigating to /materials/new.
+ */
+import { useEffect, useState } from 'react'
+import { api } from '../lib/api'
+import type { Material } from '../types/material'
+import MaterialForm, { defaultMaterialFormValues, formValuesToBody, type MaterialFormValues } from './MaterialForm'
+
+interface Props {
+  onClose: () => void
+  onCreated: (m: Material) => void
+}
+
+export default function CreateMaterialModal({ onClose, onCreated }: Props) {
+  const [values, setValues] = useState<MaterialFormValues>(defaultMaterialFormValues())
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  // Prevent body scroll while modal is open
+  useEffect(() => {
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = '' }
+  }, [])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError('')
+    try {
+      const res = await api.post<{ status: string; data: Material }>('/api/materials', formValuesToBody(values))
+      onCreated(res.data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit material')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0,0,0,0.45)' }}
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto
+                   shadow-xl flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-gray-100">
+          <h2
+            className="text-xl font-semibold text-ink"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Submit material
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-muted
+                       hover:bg-gray-100 hover:text-ink transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-6">
+          <MaterialForm values={values} onChange={setValues} />
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-xl
+                         text-sm font-semibold text-white hover:opacity-90 transition-all
+                         disabled:opacity-50"
+              style={{ background: 'var(--color-primary)' }}
+            >
+              {submitting ? 'Submitting…' : 'Submit material'}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-xl
+                         border-2 border-surface-2 text-ink text-sm font-semibold
+                         hover:border-ink transition-all"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/MaterialDetailModal.tsx
+++ b/frontend/src/components/MaterialDetailModal.tsx
@@ -1,9 +1,16 @@
 /**
  * MaterialDetailModal — shows full material details in an overlay modal.
- * Replaces navigation to /materials/:id so users stay on the current page.
+ * When onSave is provided (admin context) an Edit button lets admins update
+ * the material in-place without leaving the page.
  */
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { api } from '../lib/api'
 import type { Material } from '../types/material'
+import MaterialForm, {
+  materialToFormValues,
+  formValuesToUpdateBody,
+  type MaterialFormValues,
+} from './MaterialForm'
 
 interface Props {
   material: Material
@@ -13,6 +20,8 @@ interface Props {
   onAdd?: (m: Material) => void
   onRemove?: (m: Material) => void
   actionPending?: boolean
+  /** When provided an Edit button is shown (admin-only usage). Called with the updated material. */
+  onSave?: (updated: Material) => void
 }
 
 export default function MaterialDetailModal({
@@ -22,15 +31,29 @@ export default function MaterialDetailModal({
   onAdd,
   onRemove,
   actionPending,
+  onSave,
 }: Props) {
-  // Close on Escape
+  const [editing, setEditing] = useState(false)
+  const [editValues, setEditValues] = useState<MaterialFormValues>(() => materialToFormValues(material))
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState('')
+
+  // Close on Escape (but not while editing — Escape cancels edit instead)
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') {
+        if (editing) {
+          setEditing(false)
+          setEditValues(materialToFormValues(material))
+          setSaveError('')
+        } else {
+          onClose()
+        }
+      }
     }
     document.addEventListener('keydown', handleKey)
     return () => document.removeEventListener('keydown', handleKey)
-  }, [onClose])
+  }, [onClose, editing, material])
 
   // Prevent body scroll while modal is open
   useEffect(() => {
@@ -38,13 +61,43 @@ export default function MaterialDetailModal({
     return () => { document.body.style.overflow = '' }
   }, [])
 
+  function handleStartEdit() {
+    setEditValues(materialToFormValues(material))
+    setSaveError('')
+    setEditing(true)
+  }
+
+  function handleCancelEdit() {
+    setEditing(false)
+    setEditValues(materialToFormValues(material))
+    setSaveError('')
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    setSaveError('')
+    try {
+      const res = await api.patch<{ status: string; data: Material }>(
+        `/api/materials/${material.id}`,
+        formValuesToUpdateBody(editValues),
+      )
+      onSave?.(res.data)
+      setEditing(false)
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save changes')
+    } finally {
+      setSaving(false)
+    }
+  }
+
   const showLabAction = !!(onAdd || onRemove)
 
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       style={{ background: 'rgba(0,0,0,0.45)' }}
-      onClick={onClose}
+      onClick={editing ? undefined : onClose}
     >
       <div
         className="bg-white rounded-2xl w-full max-w-lg max-h-[88vh] overflow-y-auto
@@ -54,34 +107,46 @@ export default function MaterialDetailModal({
         {/* Header */}
         <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-0">
           <div className="flex-1 min-w-0">
-            {/* Badges */}
-            <div className="flex flex-wrap gap-1.5 mb-2">
-              <span
-                className="text-xs font-medium px-2.5 py-1 rounded-full"
-                style={{ background: 'var(--color-blush)', color: 'var(--color-plum)' }}
+            {!editing && (
+              <>
+                {/* Badges */}
+                <div className="flex flex-wrap gap-1.5 mb-2">
+                  <span
+                    className="text-xs font-medium px-2.5 py-1 rounded-full"
+                    style={{ background: 'var(--color-blush)', color: 'var(--color-plum)' }}
+                  >
+                    {material.type}
+                  </span>
+                  <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-gray-100 text-gray-600 capitalize">
+                    {material.category}
+                  </span>
+                  {material.is_verified && (
+                    <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-emerald-50 text-emerald-700">
+                      ✓ Verified
+                    </span>
+                  )}
+                </div>
+                <h2
+                  className="text-xl font-semibold text-ink leading-tight"
+                  style={{ fontFamily: 'var(--font-display)' }}
+                >
+                  {material.name}
+                </h2>
+              </>
+            )}
+            {editing && (
+              <h2
+                className="text-xl font-semibold text-ink leading-tight"
+                style={{ fontFamily: 'var(--font-display)' }}
               >
-                {material.type}
-              </span>
-              <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-gray-100 text-gray-600 capitalize">
-                {material.category}
-              </span>
-              {material.is_verified && (
-                <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-emerald-50 text-emerald-700">
-                  ✓ Verified
-                </span>
-              )}
-            </div>
-            <h2
-              className="text-xl font-semibold text-ink leading-tight"
-              style={{ fontFamily: 'var(--font-display)' }}
-            >
-              {material.name}
-            </h2>
+                Edit material
+              </h2>
+            )}
           </div>
 
           <div className="flex items-center gap-2 shrink-0">
-            {/* Lab action */}
-            {showLabAction && (
+            {/* Lab action (read-only mode only) */}
+            {!editing && showLabAction && (
               <button
                 type="button"
                 onClick={() => { inLab ? onRemove?.(material) : onAdd?.(material) }}
@@ -113,10 +178,27 @@ export default function MaterialDetailModal({
               </button>
             )}
 
+            {/* Edit button (read-only mode, admin context) */}
+            {!editing && onSave && (
+              <button
+                type="button"
+                onClick={handleStartEdit}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium
+                           border-2 border-gray-200 text-ink hover:border-ink transition-colors"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5
+                       m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+                Edit
+              </button>
+            )}
+
             {/* Close */}
             <button
               type="button"
-              onClick={onClose}
+              onClick={editing ? handleCancelEdit : onClose}
               className="w-8 h-8 rounded-lg flex items-center justify-center text-muted
                          hover:bg-gray-100 hover:text-ink transition-colors"
             >
@@ -127,97 +209,130 @@ export default function MaterialDetailModal({
           </div>
         </div>
 
-        {/* Body */}
-        <div className="px-6 pb-6 pt-4 space-y-4">
-          {/* Image */}
-          {material.image_url && (
-            <img
-              src={material.image_url}
-              alt={material.name}
-              className="w-full max-h-52 object-contain rounded-xl border border-gray-200 bg-gray-50"
-            />
-          )}
+        {/* Body — read-only view */}
+        {!editing && (
+          <div className="px-6 pb-6 pt-4 space-y-4">
+            {/* Image */}
+            {material.image_url && (
+              <img
+                src={material.image_url}
+                alt={material.name}
+                className="w-full max-h-52 object-contain rounded-xl border border-gray-200 bg-gray-50"
+              />
+            )}
 
-          {/* Description */}
-          {material.description && (
-            <section>
-              <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-1.5">
-                Description
-              </h3>
-              <p className="text-sm text-ink leading-relaxed">{material.description}</p>
-            </section>
-          )}
+            {/* Description */}
+            {material.description && (
+              <section>
+                <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-1.5">
+                  Description
+                </h3>
+                <p className="text-sm text-ink leading-relaxed">{material.description}</p>
+              </section>
+            )}
 
-          {/* Details */}
-          {(material.supplier || material.typical_cost_usd != null || material.link) && (
-            <section>
-              <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">
-                Details
-              </h3>
-              <dl className="space-y-1.5 text-sm">
-                {material.supplier && (
-                  <div className="flex gap-2">
-                    <dt className="w-28 shrink-0 text-muted">Supplier</dt>
-                    <dd className="text-ink">{material.supplier}</dd>
-                  </div>
-                )}
-                {material.typical_cost_usd != null && (
-                  <div className="flex gap-2">
-                    <dt className="w-28 shrink-0 text-muted">Typical cost</dt>
-                    <dd className="text-ink">${material.typical_cost_usd.toFixed(2)}</dd>
-                  </div>
-                )}
-                {material.link && (
-                  <div className="flex gap-2">
-                    <dt className="w-28 shrink-0 text-muted">Product link</dt>
-                    <dd>
-                      <a
-                        href={material.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary hover:underline break-all"
-                      >
-                        {material.link}
-                      </a>
-                    </dd>
-                  </div>
-                )}
-              </dl>
-            </section>
-          )}
+            {/* Details */}
+            {(material.supplier || material.typical_cost_usd != null || material.link) && (
+              <section>
+                <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+                  Details
+                </h3>
+                <dl className="space-y-1.5 text-sm">
+                  {material.supplier && (
+                    <div className="flex gap-2">
+                      <dt className="w-28 shrink-0 text-muted">Supplier</dt>
+                      <dd className="text-ink">{material.supplier}</dd>
+                    </div>
+                  )}
+                  {material.typical_cost_usd != null && (
+                    <div className="flex gap-2">
+                      <dt className="w-28 shrink-0 text-muted">Typical cost</dt>
+                      <dd className="text-ink">${material.typical_cost_usd.toFixed(2)}</dd>
+                    </div>
+                  )}
+                  {material.link && (
+                    <div className="flex gap-2">
+                      <dt className="w-28 shrink-0 text-muted">Product link</dt>
+                      <dd>
+                        <a
+                          href={material.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:underline break-all"
+                        >
+                          {material.link}
+                        </a>
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+              </section>
+            )}
 
-          {/* Safety notes */}
-          {material.safety_notes && (
-            <section className="bg-amber-50 rounded-xl p-4">
-              <h3 className="text-xs font-semibold text-amber-700 uppercase tracking-wide mb-1.5">
-                ⚠ Safety Notes
-              </h3>
-              <p className="text-sm text-amber-900 whitespace-pre-line">{material.safety_notes}</p>
-            </section>
-          )}
+            {/* Safety notes */}
+            {material.safety_notes && (
+              <section className="bg-amber-50 rounded-xl p-4">
+                <h3 className="text-xs font-semibold text-amber-700 uppercase tracking-wide mb-1.5">
+                  ⚠ Safety Notes
+                </h3>
+                <p className="text-sm text-amber-900 whitespace-pre-line">{material.safety_notes}</p>
+              </section>
+            )}
 
-          {/* Tags */}
-          {material.tags.length > 0 && (
-            <section>
-              <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">Tags</h3>
-              <div className="flex flex-wrap gap-1.5">
-                {material.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="text-xs px-2.5 py-1 rounded-lg font-medium"
-                    style={{
-                      fontFamily: 'var(--font-mono)',
-                      background: 'var(--color-blush)',
-                      color: 'var(--color-plum)',
-                    }}
-                  >
-                    #{tag}
-                  </span>
-                ))}
-              </div>
-            </section>
-          )}
-        </div>
+            {/* Tags */}
+            {material.tags.length > 0 && (
+              <section>
+                <h3 className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">Tags</h3>
+                <div className="flex flex-wrap gap-1.5">
+                  {material.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="text-xs px-2.5 py-1 rounded-lg font-medium"
+                      style={{
+                        fontFamily: 'var(--font-mono)',
+                        background: 'var(--color-blush)',
+                        color: 'var(--color-plum)',
+                      }}
+                    >
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        )}
+
+        {/* Body — edit form */}
+        {editing && (
+          <form onSubmit={handleSave} className="px-6 pb-6 pt-4 space-y-6">
+            <MaterialForm values={editValues} onChange={setEditValues} />
+
+            {saveError && <p className="text-sm text-red-600">{saveError}</p>}
+
+            <div className="flex gap-3 pt-1">
+              <button
+                type="submit"
+                disabled={saving}
+                className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-xl
+                           text-sm font-semibold text-white hover:opacity-90 transition-all
+                           disabled:opacity-50"
+                style={{ background: 'var(--color-primary)' }}
+              >
+                {saving ? 'Saving…' : 'Save changes'}
+              </button>
+              <button
+                type="button"
+                onClick={handleCancelEdit}
+                className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-xl
+                           border-2 border-surface-2 text-ink text-sm font-semibold
+                           hover:border-ink transition-all"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/components/MaterialForm.tsx
+++ b/frontend/src/components/MaterialForm.tsx
@@ -1,4 +1,4 @@
-import type { MaterialCategory, MaterialType } from '../types/material'
+import type { Material, MaterialCategory, MaterialType } from '../types/material'
 import ImageUpload from './ImageUpload'
 
 const CATEGORY_OPTIONS: { value: MaterialCategory; label: string }[] = [
@@ -37,6 +37,22 @@ export function defaultMaterialFormValues(): MaterialFormValues {
   }
 }
 
+/** Populate form from an existing Material (for edit mode). */
+export function materialToFormValues(m: Material): MaterialFormValues {
+  return {
+    name: m.name,
+    type: m.type,
+    category: m.category,
+    description: m.description ?? '',
+    link: m.link ?? '',
+    supplier: m.supplier ?? '',
+    typical_cost_usd: m.typical_cost_usd != null ? String(m.typical_cost_usd) : '',
+    safety_notes: m.safety_notes ?? '',
+    tags: m.tags.join(', '),
+    image_url: m.image_url ?? '',
+  }
+}
+
 export function formValuesToBody(v: MaterialFormValues) {
   return {
     name: v.name,
@@ -49,6 +65,22 @@ export function formValuesToBody(v: MaterialFormValues) {
     ...(v.safety_notes ? { safety_notes: v.safety_notes } : {}),
     tags: v.tags.split(',').map((t) => t.trim()).filter(Boolean),
     ...(v.image_url ? { image_url: v.image_url } : {}),
+  }
+}
+
+/** Like formValuesToBody but includes null for cleared optional fields (for PATCH). */
+export function formValuesToUpdateBody(v: MaterialFormValues) {
+  return {
+    name: v.name,
+    type: v.type as MaterialType,
+    category: v.category as MaterialCategory,
+    description: v.description || null,
+    link: v.link || null,
+    supplier: v.supplier || null,
+    typical_cost_usd: v.typical_cost_usd ? parseFloat(v.typical_cost_usd) : null,
+    safety_notes: v.safety_notes || null,
+    tags: v.tags.split(',').map((t) => t.trim()).filter(Boolean),
+    image_url: v.image_url || null,
   }
 }
 


### PR DESCRIPTION
Closes #68

## What changed

### Backend
- **`backend/src/middleware/auth.ts`** — new `requireAdmin` middleware: fetches the caller's Firestore user doc and returns 403 if `is_admin !== true`
- **`backend/src/types/material.ts`** — add `UpdateMaterialBody` (all optional fields, nullable for clearable ones + `is_verified`)
- **`backend/src/controllers/materialController.ts`** — add `updateMaterial` handler (`PATCH /api/materials/:id`): validates supplied fields, writes a partial patch, returns the updated document
- **`backend/src/routes/materials.ts`** — register `PATCH /:id` behind `requireAuth + requireAdmin`

### Frontend
- **`MaterialForm.tsx`** — export `materialToFormValues(m)` (pre-populate form from an existing material) and `formValuesToUpdateBody(v)` (PATCH body that explicitly sends `null` for cleared optional fields)
- **`CreateMaterialModal.tsx`** _(new)_ — modal overlay wrapping `MaterialForm`; calls `POST /api/materials` and calls `onCreated(m)` on success
- **`MaterialDetailModal.tsx`** — add optional `onSave` prop; when provided, an **Edit** button appears in the header. Clicking it switches the modal body to an editable `MaterialForm` pre-filled with the material's current values. Saving calls `PATCH /api/materials/:id` and calls `onSave(updated)`. Escape key cancels edit instead of closing the modal while in edit mode.
- **`Materials.tsx`** — replace the `/materials/new` link with a button opening `CreateMaterialModal`; add `handleMaterialCreated` (prepends new material to the correct list) and `handleMaterialUpdated` (replaces the material in-place in both lists and refreshes `selectedMaterial`); pass `onSave` to `MaterialDetailModal`

## Test plan
- [ ] As admin, click **Submit material** → modal opens, fill form, submit → new card appears at top of the correct section without page reload
- [ ] Click a material card → detail modal opens with an **Edit** button
- [ ] Click Edit → form appears pre-populated; make changes → Save → modal returns to read-only view with updated data; card in the list reflects changes
- [ ] Click Edit, then Cancel (or press Escape) → modal returns to read-only with original data unchanged
- [ ] Non-admin: `PATCH /api/materials/:id` returns 403

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15