### PR TITLE
feat: bulk upsert by name + pipe-separated tags support (closes #70)

### DIFF
--- a/backend/src/routes/materials.ts
+++ b/backend/src/routes/materials.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import { requireAuth, requireAdmin } from '../middleware/auth'
-import { listMaterials, createMaterial, getMaterial, updateMaterial } from '../controllers/materialController'
+import { listMaterials, createMaterial, getMaterial, updateMaterial, bulkUpsertMaterials } from '../controllers/materialController'
 
 const router = Router()
 
@@ -13,6 +13,7 @@ router.use(requireAuth)
 router.post('/', createMaterial)
 
 // Admin required
+router.post('/bulk-upsert', requireAdmin, bulkUpsertMaterials)
 router.patch('/:id', requireAdmin, updateMaterial)
 
 export default router


### PR DESCRIPTION
Closes #70

## What changed

### Backend

**`POST /api/materials/bulk-upsert`** (admin-only, new endpoint)
- Accepts `{ materials: CreateMaterialBody[] }` (max 500 items)
- For each item: does an exact-case `name` query in Firestore
  - Match found → overwrites all fields on the existing document (`updated_at` bumped)
  - No match → creates a new document (same as the existing `POST /api/materials`)
- Returns `{ status: 'ok', results: [...] }` where each result is either `{ name, action: 'created'|'updated', id }` or `{ name, error }` — errors are per-item so one bad row doesn't abort the whole batch
- Registered at `router.post('/bulk-upsert', requireAdmin, ...)` — must appear before `/:id` routes to avoid route shadowing

### Frontend

**`BulkUploadMaterialsModal`**
- Now sends a single `POST /api/materials/bulk-upsert` request with all rows instead of N individual `POST /api/materials` calls
- Tag parser splits on `/[|,]/` — both `chemistry|biology|lab` and `chemistry,biology,lab` work
- Results panel now shows three distinct counts: **created** (green), **updated** (blue), **failed** (red); errors are displayed by material name rather than CSV row number

## CSV tag format going forward

Use `|` as the separator in the `tags` column:

```
name,type,category,tags
Erlenmeyer Flask,Consumable,glassware,glassware|volumetric|lab
```

Comma-separated tags also still work if the field is quoted: `"glassware,volumetric,lab"`

## Test plan
- [ ] Upload CSV with `chemistry|biology|physics` tags → materials created with tags array `['chemistry', 'biology', 'physics']`
- [ ] Re-upload same CSV with one field changed → existing material updated, not duplicated
- [ ] Row with missing required field → shows per-item error in results, other rows still process
- [ ] Non-admin token → `POST /api/materials/bulk-upsert` returns 403

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15