### PR TITLE
feat: dynamic admin-managed categories with emoji (closes #72)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import usersRouter from './routes/users'
 import designsRouter from './routes/designs'
 import materialsRouter from './routes/materials'
 import labRouter from './routes/lab'
+import categoriesRouter from './routes/categories'
 
 const app = express()
 
@@ -38,6 +39,7 @@ app.use('/api/users', usersRouter)
 app.use('/api/designs', designsRouter)
 app.use('/api/materials', materialsRouter)
 app.use('/api/lab', labRouter)
+app.use('/api/categories', categoriesRouter)
 
 // Error handling (must be last)
 app.use(notFound)

--- a/backend/src/controllers/categoryController.ts
+++ b/backend/src/controllers/categoryController.ts
@@ -1,0 +1,149 @@
+import { Request, Response, NextFunction } from 'express'
+import { adminDb } from '../lib/firebase'
+import { AppError } from '../middleware/errorHandler'
+
+const COLLECTION = 'categories'
+
+export interface Category {
+  id: string      // slug — also the Firestore document ID and the value stored on materials
+  name: string    // display name
+  emoji: string   // optional emoji prefix (empty string = none)
+  order: number   // ascending sort order
+}
+
+const DEFAULTS: Category[] = [
+  { id: 'glassware',  name: 'Glassware',   emoji: '🫙', order: 0 },
+  { id: 'reagent',    name: 'Reagent',     emoji: '⚗️',  order: 1 },
+  { id: 'equipment',  name: 'Instruments', emoji: '🔬', order: 2 },
+  { id: 'biological', name: 'Biological',  emoji: '🧬', order: 3 },
+  { id: 'other',      name: 'Other',       emoji: '📦', order: 4 },
+]
+
+function notFound(): AppError {
+  const err: AppError = new Error('Category not found')
+  err.statusCode = 404
+  return err
+}
+
+function badRequest(msg: string): AppError {
+  const err: AppError = new Error(msg)
+  err.statusCode = 400
+  return err
+}
+
+// ─── GET /api/categories ──────────────────────────────────────────────────────
+// Public. Auto-seeds defaults into Firestore on first call if collection empty.
+export async function listCategories(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const snap = await adminDb.collection(COLLECTION).orderBy('order').get()
+
+    if (snap.empty) {
+      const batch = adminDb.batch()
+      for (const cat of DEFAULTS) {
+        batch.set(adminDb.collection(COLLECTION).doc(cat.id), cat)
+      }
+      await batch.commit()
+      res.json({ status: 'ok', data: DEFAULTS })
+      return
+    }
+
+    res.json({ status: 'ok', data: snap.docs.map((d) => d.data() as Category) })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── POST /api/categories ─────────────────────────────────────────────────────
+// Admin-only. The `id` (slug) is auto-generated from the name if not provided.
+export async function createCategory(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { name, emoji } = req.body as { name?: string; emoji?: string }
+
+    if (!name?.trim()) return next(badRequest('name is required'))
+
+    // Derive slug: lowercase, collapse non-alphanumeric to underscore
+    const id = name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_|_$/g, '')
+
+    if (!id) return next(badRequest('name produced an empty slug'))
+
+    const existing = await adminDb.collection(COLLECTION).doc(id).get()
+    if (existing.exists) {
+      const err: AppError = new Error(`Category "${id}" already exists`)
+      err.statusCode = 409
+      return next(err)
+    }
+
+    // Assign next order value
+    const allSnap = await adminDb.collection(COLLECTION).orderBy('order', 'desc').limit(1).get()
+    const order = allSnap.empty ? 0 : ((allSnap.docs[0].data() as Category).order ?? 0) + 1
+
+    const cat: Category = {
+      id,
+      name: name.trim(),
+      emoji: emoji?.trim() ?? '',
+      order,
+    }
+
+    await adminDb.collection(COLLECTION).doc(id).set(cat)
+    res.status(201).json({ status: 'ok', data: cat })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── PATCH /api/categories/:id ────────────────────────────────────────────────
+// Admin-only. Only name and emoji are mutable (id/slug is immutable).
+export async function updateCategory(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const ref = adminDb.collection(COLLECTION).doc(req.params.id)
+    const snap = await ref.get()
+    if (!snap.exists) return next(notFound())
+
+    const { name, emoji } = req.body as { name?: string; emoji?: string }
+    if (name !== undefined && !name.trim()) return next(badRequest('name cannot be empty'))
+
+    const patch: Partial<Category> = {}
+    if (name  !== undefined) patch.name  = name.trim()
+    if (emoji !== undefined) patch.emoji = emoji.trim()
+
+    await ref.update(patch)
+    const updated = await ref.get()
+    res.json({ status: 'ok', data: updated.data() as Category })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── DELETE /api/categories/:id ───────────────────────────────────────────────
+// Admin-only.
+export async function deleteCategory(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const ref = adminDb.collection(COLLECTION).doc(req.params.id)
+    const snap = await ref.get()
+    if (!snap.exists) return next(notFound())
+    await ref.delete()
+    res.json({ status: 'ok' })
+  } catch (err) {
+    next(err)
+  }
+}

--- a/backend/src/controllers/materialController.ts
+++ b/backend/src/controllers/materialController.ts
@@ -8,19 +8,11 @@ import {
   CreateMaterialBody,
   UpdateMaterialBody,
   MaterialType,
-  MaterialCategory,
 } from '../types/material'
 
 const MATERIALS = 'materials'
 
 const MATERIAL_TYPES: MaterialType[] = ['Consumable', 'Equipment']
-const MATERIAL_CATEGORIES: MaterialCategory[] = [
-  'glassware',
-  'reagent',
-  'equipment',
-  'biological',
-  'other',
-]
 
 function toResponse(m: Material): MaterialResponse {
   return {
@@ -46,8 +38,7 @@ function validateCreate(body: CreateMaterialBody): string | null {
   if (!body.name?.trim()) return 'name is required'
   if (!body.type || !MATERIAL_TYPES.includes(body.type))
     return `type must be one of: ${MATERIAL_TYPES.join(', ')}`
-  if (!body.category || !MATERIAL_CATEGORIES.includes(body.category))
-    return `category must be one of: ${MATERIAL_CATEGORIES.join(', ')}`
+  if (!body.category?.trim()) return 'category is required'
   if (body.tags !== undefined && body.tags.length > 10) return 'tags cannot exceed 10'
   return null
 }
@@ -165,7 +156,7 @@ export async function listMaterials(
 
     if (tags) {
       query = query.where('tags', 'array-contains', tags as string)
-    } else if (category && MATERIAL_CATEGORIES.includes(category as MaterialCategory)) {
+    } else if (category) {
       query = query.where('category', '==', category as string)
     } else if (type && MATERIAL_TYPES.includes(type as MaterialType)) {
       query = query.where('type', '==', type as string)
@@ -249,8 +240,8 @@ export async function updateMaterial(
     if (body.type !== undefined && !MATERIAL_TYPES.includes(body.type)) {
       return next(badRequest(`type must be one of: ${MATERIAL_TYPES.join(', ')}`))
     }
-    if (body.category !== undefined && !MATERIAL_CATEGORIES.includes(body.category)) {
-      return next(badRequest(`category must be one of: ${MATERIAL_CATEGORIES.join(', ')}`))
+    if (body.category !== undefined && !body.category.trim()) {
+      return next(badRequest('category cannot be empty'))
     }
     if (body.tags !== undefined && body.tags.length > 10) {
       return next(badRequest('tags cannot exceed 10'))

--- a/backend/src/routes/categories.ts
+++ b/backend/src/routes/categories.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express'
+import { requireAuth, requireAdmin } from '../middleware/auth'
+import {
+  listCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from '../controllers/categoryController'
+
+const router = Router()
+
+// Public
+router.get('/', listCategories)
+
+// Admin required
+router.use(requireAuth)
+router.post('/',    requireAdmin, createCategory)
+router.patch('/:id',  requireAdmin, updateCategory)
+router.delete('/:id', requireAdmin, deleteCategory)
+
+export default router

--- a/backend/src/types/material.ts
+++ b/backend/src/types/material.ts
@@ -4,7 +4,8 @@ import { Timestamp } from 'firebase-admin/firestore'
 
 export type MaterialType = 'Consumable' | 'Equipment'
 
-export type MaterialCategory = 'glassware' | 'reagent' | 'equipment' | 'biological' | 'other'
+/** Dynamically managed — see /api/categories. The value is the category slug (e.g. 'glassware'). */
+export type MaterialCategory = string
 
 // ─── Primary document ─────────────────────────────────────────────────────────
 

--- a/frontend/src/components/ManageCategoriesModal.tsx
+++ b/frontend/src/components/ManageCategoriesModal.tsx
@@ -1,0 +1,322 @@
+/**
+ * ManageCategoriesModal — admin CRUD for the categories collection.
+ * Each category has a display name, an optional emoji, and a slug (id)
+ * that is auto-derived from the name and used as the `category` field on materials.
+ */
+import { useEffect, useState } from 'react'
+import { api } from '../lib/api'
+import type { Category } from '../types/category'
+
+interface Props {
+  categories: Category[]
+  onClose: () => void
+  /** Called with the updated list after any add/edit/delete so the parent can re-render. */
+  onChange: (updated: Category[]) => void
+}
+
+interface EditState {
+  name: string
+  emoji: string
+}
+
+function slugify(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '')
+}
+
+export default function ManageCategoriesModal({ categories: initial, onClose, onChange }: Props) {
+  const [items, setItems]         = useState<Category[]>(initial)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editValues, setEditValues] = useState<EditState>({ name: '', emoji: '' })
+  const [addForm, setAddForm]     = useState<EditState>({ name: '', emoji: '' })
+  const [showAdd, setShowAdd]     = useState(false)
+  const [saving, setSaving]       = useState(false)
+  const [error, setError]         = useState('')
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        if (editingId) { setEditingId(null); setError('') }
+        else onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose, editingId])
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = '' }
+  }, [])
+
+  function startEdit(cat: Category) {
+    setEditingId(cat.id)
+    setEditValues({ name: cat.name, emoji: cat.emoji })
+    setError('')
+  }
+
+  function cancelEdit() {
+    setEditingId(null)
+    setError('')
+  }
+
+  async function saveEdit(id: string) {
+    if (!editValues.name.trim()) { setError('Name cannot be empty'); return }
+    setSaving(true); setError('')
+    try {
+      const res = await api.patch<{ status: string; data: Category }>(
+        `/api/categories/${id}`,
+        { name: editValues.name.trim(), emoji: editValues.emoji.trim() },
+      )
+      const updated = items.map((c) => (c.id === id ? res.data : c))
+      setItems(updated)
+      onChange(updated)
+      setEditingId(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setSaving(true); setError('')
+    try {
+      await api.delete(`/api/categories/${id}`)
+      const updated = items.filter((c) => c.id !== id)
+      setItems(updated)
+      onChange(updated)
+      if (editingId === id) setEditingId(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleAdd() {
+    if (!addForm.name.trim()) { setError('Name cannot be empty'); return }
+    setSaving(true); setError('')
+    try {
+      const res = await api.post<{ status: string; data: Category }>(
+        '/api/categories',
+        { name: addForm.name.trim(), emoji: addForm.emoji.trim() },
+      )
+      const updated = [...items, res.data]
+      setItems(updated)
+      onChange(updated)
+      setAddForm({ name: '', emoji: '' })
+      setShowAdd(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add category')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const addSlug = slugify(addForm.name)
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0,0,0,0.45)' }}
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-2xl w-full max-w-md max-h-[88vh] overflow-y-auto shadow-xl flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-gray-100">
+          <div>
+            <h2 className="text-xl font-semibold text-ink" style={{ fontFamily: 'var(--font-display)' }}>
+              Edit Categories
+            </h2>
+            <p className="text-xs text-muted mt-0.5">
+              Changes apply immediately across all pages.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-muted hover:bg-gray-100 hover:text-ink transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Category list */}
+        <div className="px-6 py-4 space-y-2 flex-1">
+          {items.length === 0 && (
+            <p className="text-sm text-muted text-center py-6">No categories yet. Add one below.</p>
+          )}
+
+          {items.map((cat) => (
+            <div key={cat.id} className="rounded-xl border-2 border-surface-2 overflow-hidden">
+              {editingId === cat.id ? (
+                /* Edit row */
+                <div className="p-3 space-y-2">
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={editValues.emoji}
+                      onChange={(e) => setEditValues((v) => ({ ...v, emoji: e.target.value }))}
+                      placeholder="Emoji"
+                      maxLength={4}
+                      className="w-16 input-sm text-center text-lg"
+                    />
+                    <input
+                      type="text"
+                      value={editValues.name}
+                      onChange={(e) => setEditValues((v) => ({ ...v, name: e.target.value }))}
+                      placeholder="Display name"
+                      maxLength={40}
+                      className="flex-1 input-sm"
+                      autoFocus
+                    />
+                  </div>
+                  <p className="text-xs text-muted">
+                    Slug (cannot change):{' '}
+                    <code className="bg-gray-100 px-1 rounded font-mono">{cat.id}</code>
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => saveEdit(cat.id)}
+                      disabled={saving}
+                      className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold
+                                 text-white hover:opacity-90 transition-all disabled:opacity-50"
+                      style={{ background: 'var(--color-primary)' }}
+                    >
+                      {saving ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelEdit}
+                      className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium
+                                 border-2 border-surface-2 text-ink hover:border-ink transition-all"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                /* Read row */
+                <div className="flex items-center gap-3 px-4 py-3">
+                  <span className="text-xl w-7 text-center shrink-0">
+                    {cat.emoji || <span className="text-gray-300 text-sm">—</span>}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-ink truncate">{cat.name}</p>
+                    <p className="text-xs text-muted font-mono">{cat.id}</p>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => startEdit(cat)}
+                      className="w-7 h-7 rounded-lg flex items-center justify-center text-muted
+                                 hover:bg-gray-100 hover:text-ink transition-colors"
+                      title="Edit"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                          d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5
+                             m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(cat.id)}
+                      disabled={saving}
+                      className="w-7 h-7 rounded-lg flex items-center justify-center text-muted
+                                 hover:bg-red-50 hover:text-red-500 transition-colors disabled:opacity-40"
+                      title="Delete"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+
+          {/* Add new category */}
+          {showAdd ? (
+            <div className="rounded-xl border-2 border-dashed border-plum/40 p-3 space-y-2">
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={addForm.emoji}
+                  onChange={(e) => setAddForm((v) => ({ ...v, emoji: e.target.value }))}
+                  placeholder="Emoji"
+                  maxLength={4}
+                  className="w-16 input-sm text-center text-lg"
+                />
+                <input
+                  type="text"
+                  value={addForm.name}
+                  onChange={(e) => setAddForm((v) => ({ ...v, name: e.target.value }))}
+                  placeholder="Category name"
+                  maxLength={40}
+                  className="flex-1 input-sm"
+                  autoFocus
+                />
+              </div>
+              {addForm.name && (
+                <p className="text-xs text-muted">
+                  Slug:{' '}
+                  <code className="bg-gray-100 px-1 rounded font-mono">
+                    {addSlug || <span className="text-red-400">invalid name</span>}
+                  </code>
+                </p>
+              )}
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={handleAdd}
+                  disabled={saving || !addSlug}
+                  className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-semibold
+                             text-white hover:opacity-90 transition-all disabled:opacity-50"
+                  style={{ background: 'var(--color-primary)' }}
+                >
+                  {saving ? 'Adding…' : 'Add category'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setShowAdd(false); setAddForm({ name: '', emoji: '' }); setError('') }}
+                  className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium
+                             border-2 border-surface-2 text-ink hover:border-ink transition-all"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => { setShowAdd(true); setError('') }}
+              className="w-full flex items-center gap-2 px-4 py-3 rounded-xl border-2 border-dashed
+                         border-surface-2 text-muted hover:border-plum hover:text-plum transition-colors text-sm font-medium"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+              </svg>
+              Add category
+            </button>
+          )}
+
+          {error && <p className="text-sm text-red-600 pt-1">{error}</p>}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/MaterialForm.tsx
+++ b/frontend/src/components/MaterialForm.tsx
@@ -1,13 +1,6 @@
 import type { Material, MaterialCategory, MaterialType } from '../types/material'
 import ImageUpload from './ImageUpload'
-
-const CATEGORY_OPTIONS: { value: MaterialCategory; label: string }[] = [
-  { value: 'glassware', label: 'Glassware' },
-  { value: 'reagent', label: 'Reagent' },
-  { value: 'equipment', label: 'Instruments' },
-  { value: 'biological', label: 'Biological' },
-  { value: 'other', label: 'Other' },
-]
+import { useCategories } from '../hooks/useCategories'
 
 export interface MaterialFormValues {
   name: string
@@ -90,6 +83,8 @@ interface Props {
 }
 
 export default function MaterialForm({ values, onChange }: Props) {
+  const { categories } = useCategories()
+
   function set<K extends keyof MaterialFormValues>(key: K, val: MaterialFormValues[K]) {
     onChange({ ...values, [key]: val })
   }
@@ -134,8 +129,10 @@ export default function MaterialForm({ values, onChange }: Props) {
             className="w-full input-sm"
           >
             <option value="">Select category…</option>
-            {CATEGORY_OPTIONS.map(({ value, label }) => (
-              <option key={value} value={value}>{label}</option>
+            {categories.map((cat) => (
+              <option key={cat.id} value={cat.id}>
+                {cat.emoji ? `${cat.emoji} ${cat.name}` : cat.name}
+              </option>
             ))}
           </select>
         </div>

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+import { api } from '../lib/api'
+import type { Category } from '../types/category'
+
+interface UseCategoriesResult {
+  categories: Category[]
+  loading: boolean
+  /** Replace the entire category list (call after admin CRUD). */
+  setCategories: React.Dispatch<React.SetStateAction<Category[]>>
+}
+
+/**
+ * Fetches the admin-managed category list from /api/categories.
+ * Each call creates its own fetch — use at the page/component level.
+ */
+export function useCategories(): UseCategoriesResult {
+  const [categories, setCategories] = useState<Category[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api
+      .get<{ status: string; data: Category[] }>('/api/categories')
+      .then(({ data }) => setCategories(data))
+      .catch(() => {
+        // Fallback to empty list; UI should handle gracefully
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { categories, loading, setCategories }
+}

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -1,0 +1,6 @@
+export interface Category {
+  id: string      // slug — stored as the `category` value on materials (e.g. 'glassware')
+  name: string    // display name
+  emoji: string   // optional emoji prefix; empty string means none
+  order: number   // ascending sort order
+}

--- a/frontend/src/types/material.ts
+++ b/frontend/src/types/material.ts
@@ -1,6 +1,7 @@
 export type MaterialType = 'Consumable' | 'Equipment'
 
-export type MaterialCategory = 'glassware' | 'reagent' | 'equipment' | 'biological' | 'other'
+/** Dynamically managed — see /api/categories. Value is the category slug (e.g. 'glassware'). */
+export type MaterialCategory = string
 
 export interface Material {
   id: string


### PR DESCRIPTION
Closes #72

## What changed

### Backend

**New: `GET /api/categories`** (public)
Returns the `categories` Firestore collection sorted by `order`. If the collection is empty on first call, auto-seeds the 5 existing defaults (`glassware`, `reagent`, `equipment`, `biological`, `other`) and returns them — no manual migration needed.

**New: `POST /api/categories`** (admin-only)
Creates a category. The slug (`id`) is auto-derived from the name (e.g. "Dry Ice" → `dry_ice`) and shown to the admin in the UI. Name and emoji are freely editable; the slug is immutable after creation.

**New: `PATCH /api/categories/:id`** (admin-only) — update name/emoji
**New: `DELETE /api/categories/:id`** (admin-only)

**`MaterialCategory` type** changed from `'glassware' | 'reagent' | …` to `string` in both `backend/src/types/material.ts` and `frontend/src/types/material.ts`. The material controller's hardcoded enum validation is replaced with a simple non-empty string check.

### Frontend

| File | Change |
|------|--------|
| `frontend/src/types/category.ts` | New `Category` interface |
| `frontend/src/hooks/useCategories.ts` | Hook that fetches `/api/categories` |
| `ManageCategoriesModal.tsx` | New modal: inline add/edit/delete for each category; each save is an immediate API call |
| `MaterialForm.tsx` | Category `<select>` options come from `useCategories()` |
| `MaterialsDrawer.tsx` | Category filter pills come from `useCategories()`, filtered to slugs present in loaded materials |
| `Materials.tsx` | Same active-category derivation; new **"Edit categories"** button opens `ManageCategoriesModal`; `setCategories` passed as `onChange` so pills update instantly without a page reload |

## Test plan
- [ ] First visit to `/materials` with empty `categories` collection → 5 defaults auto-seeded, pills appear
- [ ] "Edit categories" → rename a category, change its emoji → pill and form dropdown update immediately
- [ ] Add a new category → appears in the form dropdown and (once a material has that category) in filter pills
- [ ] Delete a category → disappears from dropdown; existing materials retain their slug, no data loss
- [ ] MaterialsDrawer on MyLab → "Add Materials" shows only categories that actually have materials

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15