### PR TITLE
fix: suppress Firebase Extensions API 403 on deploy

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -32,6 +32,7 @@
       }
     ]
   },
+  "extensions": {},
   "functions": [
     {
       "source": "backend",


### PR DESCRIPTION
## Summary

- Add `"extensions": {}` to `firebase.json`

## Problem

Every `firebase deploy` probes the Extensions API (`firebaseextensions.googleapis.com`) at startup, even when `--only hosting,functions` is passed. The CI token lacks the Firebase Extensions Admin IAM role, so it gets a 403 and aborts the entire deploy.

## Fix

Declaring an empty `extensions` block in `firebase.json` tells firebase-tools this project has no extensions to manage, causing it to skip that API call entirely.

## Test plan

- [ ] Merge and confirm the Deploy to Firebase workflow completes without the `403 The caller does not have permission` error

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15