### PR TITLE
fix: pin firebase-tools to v12 to stop Extensions API 403

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -130,7 +130,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools
+        run: npm install -g firebase-tools@12
 
       - name: Deploy to Firebase
         run: firebase deploy --only hosting,functions --non-interactive --force --project "$FIREBASE_PROJECT_ID"


### PR DESCRIPTION
## Problem

Even after adding `"extensions": {}` to `firebase.json`, the deploy still 403s on the Extensions API. That fix only works with older firebase-tools. Newer versions (v13+) unconditionally list extension instances at deploy startup, regardless of `--only hosting,functions` or what's in `firebase.json`. The CI token doesn't have the Firebase Extensions Admin role, so it fails.

## Fix

Pin `firebase-tools` to v12 in CI:

```yaml
run: npm install -g firebase-tools@12
```

v12 does not make the extensions listing call when extensions are not being deployed. This is the correct behavior for our setup and avoids needing to grant any additional IAM roles.

## Notes

- The `"extensions": {}` entry in `firebase.json` from the previous PR is harmless and can stay
- If we ever need to upgrade to firebase-tools v13+, we'd need to grant the `Firebase Extensions Admin` role to the CI service account/token

## Test plan

- [ ] Merge and confirm the Deploy to Firebase workflow completes without the `403 The caller does not have permission` error

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15