### PR TITLE
fix: remove extensions key incompatible with firebase-tools v12

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -32,7 +32,6 @@
       }
     ]
   },
-  "extensions": {},
   "functions": [
     {
       "source": "backend",


### PR DESCRIPTION
## Problem

The previous PR added `"extensions": {}` to `firebase.json` as a workaround for the 403 on the Extensions API. PR #92 then pinned `firebase-tools@12` in CI to avoid that API call. But `firebase-tools@12` doesn't know the `extensions` key and now fails with:

```
Error: Failed to parse build specification:
- FirebaseError Unexpected key extensions. You may need to install a newer version of the Firebase CLI.
```

## Fix

Remove the `"extensions": {}` line from `firebase.json`. It was only ever a workaround for the v13+ behaviour that we've already fixed by pinning to v12.

## Test plan

- [ ] Merge and confirm deploy completes without either the `403` or the `Unexpected key extensions` error

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15