### PR TITLE
fix: use firebase-functions v2 HTTPS API to keep function as Gen 2

### DIFF
--- a/backend/src/functions.ts
+++ b/backend/src/functions.ts
@@ -2,7 +2,7 @@
  * Firebase Cloud Functions entry point.
  * Wraps the Express app as a callable HTTPS function named "api".
  */
-import * as functions from 'firebase-functions'
+import { onRequest } from 'firebase-functions/v2/https'
 import app from './app'
 
-export const api = functions.https.onRequest(app)
+export const api = onRequest(app)


### PR DESCRIPTION
## What failed

```
Error: Cannot set CPU on the functions api because they are GCF gen 1
```

## Why

The existing deployed function `api` is **Gen 2** (firebase-functions v6 defaults to Gen 2 for `https.onRequest`). PR #94 downgraded to firebase-functions v4, which defaults `https.onRequest()` to **Gen 1**. Firebase does not allow changing a function's generation in place — firebase-tools v12 threw this error when it tried to apply the existing Gen 2 CPU config to the now-Gen-1 function.

## Fix

Keep firebase-functions v4 (its build manifest has no `extensions` key, so firebase-tools v12 can parse it cleanly), but switch the import to the **v2 HTTPS API** which explicitly targets Gen 2:

```typescript
// before
import * as functions from 'firebase-functions'
export const api = functions.https.onRequest(app)

// after
import { onRequest } from 'firebase-functions/v2/https'
export const api = onRequest(app)
```

This keeps the function as Gen 2, matching the existing deployed function, while staying on the firebase-functions v4 build spec format that firebase-tools v12 understands.

## Test plan

- [ ] Merge and confirm deploy completes — no Extensions API 403, no build spec parse error, no CPU/generation conflict

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15