### PR TITLE
feat: design version control

### DIFF
--- a/backend/src/routes/designs.ts
+++ b/backend/src/routes/designs.ts
@@ -7,6 +7,8 @@ import {
   getDesign,
   updateDesign,
   publishDesign,
+  listDesignVersions,
+  getDesignVersion,
   forkDesign,
   deleteDesign,
 } from '../controllers/designController'
@@ -15,7 +17,9 @@ const router = Router()
 
 // Public — no auth required
 router.get('/', listDesigns)
-router.get('/:id', optionalAuth, getDesign)  // optionalAuth sets req.user so authors can view their drafts
+router.get('/:id', optionalAuth, getDesign)           // optionalAuth so authors see their draft state
+router.get('/:id/versions', optionalAuth, listDesignVersions)
+router.get('/:id/versions/:versionNum', optionalAuth, getDesignVersion)
 
 // Auth required for all mutations and personal views
 router.use(requireAuth)

--- a/backend/src/types/design.ts
+++ b/backend/src/types/design.ts
@@ -126,7 +126,9 @@ export interface Design {
   // Metadata (system-managed)
   status: DesignStatus
   is_public: boolean           // true when status is 'published' or 'locked'
-  version: number
+  version: number              // internal edit counter, increments on every PATCH
+  published_version: number    // user-facing version number, increments on each publish (0 = never published)
+  has_draft_changes: boolean   // true when a published design has unsaved edits in its draft sub-document
   author_ids: string[]
   review_status: ReviewStatus
   review_count: number
@@ -177,6 +179,25 @@ export type UpdateDesignBody = Partial<CreateDesignBody>
 export interface ForkDesignBody {
   fork_type: ForkType
   fork_rationale: string
+}
+
+export interface PublishDesignBody {
+  changelog?: string
+}
+
+// ─── Version history types ────────────────────────────────────────────────────
+
+// Summary returned by GET /api/designs/:id/versions
+export interface DesignVersionSummary {
+  version_number: number
+  published_at: string   // ISO string
+  published_by: string   // uid
+  changelog?: string
+}
+
+// Full snapshot returned by GET /api/designs/:id/versions/:versionNum
+export interface DesignVersionSnapshot extends DesignVersionSummary {
+  data: DesignResponse
 }
 
 // ─── API response types ───────────────────────────────────────────────────────

--- a/frontend/src/types/design.ts
+++ b/frontend/src/types/design.ts
@@ -69,6 +69,8 @@ export interface Design {
   status: DesignStatus
   is_public: boolean
   version: number
+  published_version: number    // user-facing version number; 0 = never published
+  has_draft_changes: boolean   // true when a published design has unsaved edits
   author_ids: string[]
   execution_count: number
   derived_design_count: number
@@ -116,4 +118,15 @@ export interface DesignListResponse {
   status: string
   data: Design[]
   count: number
+}
+
+export interface DesignVersionSummary {
+  version_number: number
+  published_at: string
+  published_by: string
+  changelog?: string
+}
+
+export interface DesignVersionSnapshot extends DesignVersionSummary {
+  data: Design
 }


### PR DESCRIPTION
Closes #96, #97, #98.

## Summary

Implements version control for Designs so that:
- Authors can edit a published design without affecting the public view until they re-publish
- Every publish creates an immutable version snapshot with an optional changelog note
- Any user can browse and compare all published versions of a design from the detail page
- The public listing always shows the last published state (never draft edits)

## How it works

**Data model**
- `published_version: number` — user-facing version counter (0 = never published), increments on each publish
- `has_draft_changes: boolean` — true when a published design has edits pending in a `draft` sub-document
- `designs/{id}/versions/{N}` — immutable published snapshots (full design state + changelog + who published)
- `designs/{id}/draft` — mutable draft sub-document; only exists when `has_draft_changes` is true

The main Firestore document **always reflects the last published state**, keeping the public listing clean. Draft edits live in the sub-document until the author publishes again.

**Backend changes**
- `GET /api/designs/:id` — returns draft content to authors when `has_draft_changes`; non-authors always see published
- `PATCH /api/designs/:id` — routes writes to draft sub-document for published designs; main document for pure drafts
- `POST /api/designs/:id/publish` — first publish: snapshot + `published_version: 1`; re-publish: merge draft → main, increment version, snapshot, delete draft. Accepts optional `changelog` body field.
- `GET /api/designs/:id/versions` — list of `{ version_number, published_at, published_by, changelog? }`
- `GET /api/designs/:id/versions/:versionNum` — full snapshot for a specific version

**Frontend changes**
- **EditDesign** — modal warning on first edit of a published design: "your changes are saved as a private draft until you publish"
- **DesignDetail** — version selector dropdown next to the title; defaults to Draft for owners-with-draft, latest published for everyone else; amber banner when viewing a historical version; Edit/Publish actions hidden when browsing historical snapshots; Publish button says "Publish draft" on re-publish

## Test plan

- [ ] Create a design and publish it (v1 appears in version history)
- [ ] Edit the published design → warning modal appears → edits save as draft → public still sees v1
- [ ] Re-publish → v2 snapshot created → public now sees v2
- [ ] Version selector shows v1 and v2; clicking v1 loads the snapshot and shows the banner
- [ ] Logged-out user on the detail page never sees the draft, always sees v2
- [ ] Fork still works; forked design starts with `published_version: 0`

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15