### PR TITLE
Fix edit warning timing, material card regression, and changelog UX

### DIFF
--- a/backend/src/types/design.ts
+++ b/backend/src/types/design.ts
@@ -123,6 +123,9 @@ export interface Design {
   seeking_collaborators: boolean
   collaboration_notes?: string
 
+  // Draft-only metadata (stripped from main doc on publish)
+  pending_changelog?: string   // changelog text saved while editing, auto-used on next publish
+
   // Metadata (system-managed)
   status: DesignStatus
   is_public: boolean           // true when status is 'published' or 'locked'
@@ -173,8 +176,10 @@ export interface CreateDesignBody {
   collaboration_notes?: string
 }
 
-// All CreateDesignBody fields are optional for updates
-export type UpdateDesignBody = Partial<CreateDesignBody>
+// All CreateDesignBody fields are optional for updates; pending_changelog is edit-only
+export interface UpdateDesignBody extends Partial<CreateDesignBody> {
+  pending_changelog?: string
+}
 
 export interface ForkDesignBody {
   fork_type: ForkType

--- a/frontend/src/types/design.ts
+++ b/frontend/src/types/design.ts
@@ -71,6 +71,7 @@ export interface Design {
   version: number
   published_version: number    // user-facing version number; 0 = never published
   has_draft_changes: boolean   // true when a published design has unsaved edits
+  pending_changelog?: string   // changelog text saved in draft, auto-used on next publish
   author_ids: string[]
   execution_count: number
   derived_design_count: number
@@ -107,7 +108,9 @@ export interface CreateDesignBody {
   disclaimers?: string
 }
 
-export type UpdateDesignBody = Partial<CreateDesignBody>
+export interface UpdateDesignBody extends Partial<CreateDesignBody> {
+  pending_changelog?: string
+}
 
 export interface ForkDesignBody {
   fork_type: ForkType


### PR DESCRIPTION
Fixes #100

## Summary

- **Edit warning moved to DesignDetail**: The "You're editing a published design" modal now shows in `DesignDetail.tsx` when the user clicks Edit on a first-time publish, before any navigation. Cancel dismisses the modal; "Got it" navigates to the edit page.
- **Material cards fixed for historical versions**: `loadMaterials` now merges into `materialMap` instead of replacing it, and a `useEffect` on `selectedSnapshot` fetches materials for each snapshot version as it is selected — so items removed in later versions still render their full card.
- **Changelog UX added end-to-end**:
  - Backend: new `pending_changelog` field on `Design` and `UpdateDesignBody`; `updateDesign` stores it in the draft sub-document; `publishDesign` uses it as the version snapshot changelog and strips it from the main doc on publish. Also fixed fall-through bugs in `getDesign`, `updateDesign`, and `publishDesign`.
  - `EditDesign`: two-column layout when `published_version > 0` — form on the left, sticky "Change Log" textarea on the right; value sent as `pending_changelog` on every save.
  - `DesignDetail`: Changelog sidebar card above About, showing the selected version's changelog, the latest published version's changelog, or the author's pending draft changelog.

## Test plan

- [ ] Click Edit on a published design with no existing draft → modal appears before the edit page loads; Cancel stays on detail page; "Got it" navigates to edit
- [ ] Click Edit on a design that already has a draft → no modal, navigates directly
- [ ] In Edit Design with a published design (version > 0): Change Log textarea is visible in the right sidebar; save → changelog is persisted; publish → version snapshot includes changelog
- [ ] In DesignDetail: Changelog card appears in sidebar for the current published version and for historical versions when a changelog exists
- [ ] View a historical version that includes a material no longer in the current design → full material card renders correctly