### PR TITLE
feat: peer review submission system (Phase 1)

### DIFF
--- a/backend/src/controllers/reviewController.ts
+++ b/backend/src/controllers/reviewController.ts
@@ -1,0 +1,477 @@
+import { randomUUID } from 'crypto'
+import { Request, Response, NextFunction } from 'express'
+import { FieldValue, Query, DocumentData } from 'firebase-admin/firestore'
+import { adminDb } from '../lib/firebase'
+import { AppError } from '../middleware/errorHandler'
+import { Design } from '../types/design'
+import {
+  Review,
+  FieldSuggestion,
+  ReadinessSignal,
+  SuggestionType,
+  CreateReviewBody,
+  CreateSuggestionBody,
+  CreateEndorsementBody,
+  ReviewResponse,
+  FieldSuggestionResponse,
+  ReviewSummary,
+  ContributingReviewer,
+} from '../types/review'
+
+const DESIGNS = 'designs'
+
+const VALID_READINESS_SIGNALS: ReadinessSignal[] = ['ready', 'almost_ready', 'needs_revision']
+const VALID_SUGGESTION_TYPES: SuggestionType[] = [
+  'suggestion',
+  'issue',
+  'question',
+  'safety_concern',
+]
+
+// ─── Error helpers ────────────────────────────────────────────────────────────
+
+function badRequest(message: string): AppError {
+  const err: AppError = new Error(message)
+  err.statusCode = 400
+  return err
+}
+
+function notFoundError(message = 'Not found'): AppError {
+  const err: AppError = new Error(message)
+  err.statusCode = 404
+  return err
+}
+
+function forbidden(message: string): AppError {
+  const err: AppError = new Error(message)
+  err.statusCode = 403
+  return err
+}
+
+// ─── Serializers ──────────────────────────────────────────────────────────────
+
+function toSuggestionResponse(s: FieldSuggestion): FieldSuggestionResponse {
+  return {
+    ...s,
+    createdAt: s.createdAt.toDate().toISOString(),
+    updatedAt: s.updatedAt.toDate().toISOString(),
+  }
+}
+
+function toReviewResponse(review: Review, suggestions: FieldSuggestion[]): ReviewResponse {
+  return {
+    ...review,
+    createdAt: review.createdAt.toDate().toISOString(),
+    updatedAt: review.updatedAt.toDate().toISOString(),
+    suggestions: suggestions.map(toSuggestionResponse),
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function reviewsRef(designId: string) {
+  return adminDb.collection(DESIGNS).doc(designId).collection('reviews')
+}
+
+async function loadSuggestions(designId: string, reviewId: string): Promise<FieldSuggestion[]> {
+  const snap = await reviewsRef(designId).doc(reviewId).collection('suggestions').get()
+  const docs = snap.docs.map((d) => d.data() as FieldSuggestion)
+  docs.sort((a, b) => a.createdAt.toMillis() - b.createdAt.toMillis())
+  return docs
+}
+
+// Loads a design, asserts it is published and not locked, and that the caller
+// is not an owner. Returns the design on success; throws AppError otherwise.
+async function requireReviewable(designId: string, callerId: string): Promise<Design> {
+  const snap = await adminDb.collection(DESIGNS).doc(designId).get()
+  if (!snap.exists) throw notFoundError('Design not found')
+
+  const design = snap.data() as Design
+
+  if (design.status !== 'published') {
+    throw forbidden('This design is not published and cannot be reviewed.')
+  }
+  if (design.execution_count > 0) {
+    throw forbidden('This design is locked because executions have begun.')
+  }
+  if (design.author_ids.includes(callerId)) {
+    throw forbidden('You cannot review your own design.')
+  }
+
+  return design
+}
+
+// ─── POST /api/designs/:id/reviews ───────────────────────────────────────────
+
+export async function submitReview(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { id } = req.params
+    const callerId = req.user!.uid
+
+    let design: Design
+    try {
+      design = await requireReviewable(id, callerId)
+    } catch (err) {
+      return next(err as AppError)
+    }
+
+    const body = req.body as CreateReviewBody
+    const generalComment = body.generalComment?.trim() || null
+    const endorsement = body.endorsement ?? false
+    const readinessSignal = body.readinessSignal ?? null
+    const suggestions: CreateSuggestionBody[] = Array.isArray(body.suggestions)
+      ? body.suggestions
+      : []
+
+    // At least one meaningful contribution required
+    if (!generalComment && suggestions.length === 0 && !endorsement) {
+      return next(
+        badRequest(
+          'A review must include at least one of: generalComment, suggestions, or endorsement.',
+        ),
+      )
+    }
+
+    // Endorsement requires a comment
+    if (endorsement && !generalComment) {
+      return next(badRequest('generalComment is required when endorsement is true.'))
+    }
+
+    // Validate readinessSignal
+    if (readinessSignal !== null && !VALID_READINESS_SIGNALS.includes(readinessSignal)) {
+      return next(
+        badRequest(`readinessSignal must be one of: ${VALID_READINESS_SIGNALS.join(', ')}`),
+      )
+    }
+
+    // Validate each suggestion
+    for (let i = 0; i < suggestions.length; i++) {
+      const s = suggestions[i]
+      const hasProposedText = !!s.proposedText?.trim()
+      const hasComment = !!s.comment?.trim()
+      if (!hasProposedText && !hasComment) {
+        return next(
+          badRequest(`suggestions[${i}]: at least one of proposedText or comment is required.`),
+        )
+      }
+      const fieldRef = s.fieldRef?.trim() || null
+      const newFieldName = s.newFieldName?.trim() || null
+      if (fieldRef && newFieldName) {
+        return next(
+          badRequest(`suggestions[${i}]: fieldRef and newFieldName are mutually exclusive.`),
+        )
+      }
+      if (!fieldRef && !newFieldName) {
+        return next(
+          badRequest(`suggestions[${i}]: one of fieldRef or newFieldName is required.`),
+        )
+      }
+      if (
+        s.suggestionType != null &&
+        !VALID_SUGGESTION_TYPES.includes(s.suggestionType)
+      ) {
+        return next(badRequest(`suggestions[${i}]: invalid suggestionType.`))
+      }
+    }
+
+    const now = FieldValue.serverTimestamp()
+    const reviewId = randomUUID()
+    const versionNumber = design.published_version
+    const batch = adminDb.batch()
+
+    const reviewDocRef = reviewsRef(id).doc(reviewId)
+    batch.set(reviewDocRef, {
+      id: reviewId,
+      designId: id,
+      versionNumber,
+      reviewerId: callerId,
+      generalComment,
+      readinessSignal,
+      endorsement,
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    for (const s of suggestions) {
+      const suggestionId = randomUUID()
+      batch.set(reviewDocRef.collection('suggestions').doc(suggestionId), {
+        id: suggestionId,
+        reviewId,
+        designId: id,
+        versionNumber,
+        fieldRef: s.fieldRef?.trim() || null,
+        newFieldName: s.newFieldName?.trim() || null,
+        proposedText: s.proposedText?.trim() || null,
+        comment: s.comment?.trim() || null,
+        suggestionType: s.suggestionType ?? null,
+        status: 'open',
+        ownerReply: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+
+    // Increment review count atomically; flip review_status on first review
+    batch.update(adminDb.collection(DESIGNS).doc(id), {
+      review_count: FieldValue.increment(1),
+      review_status:
+        design.review_status === 'unreviewed' ? 'under_review' : design.review_status,
+      updated_at: now,
+    })
+
+    await batch.commit()
+
+    // Read back the committed documents
+    const [reviewSnap, suggsSnap] = await Promise.all([
+      reviewDocRef.get(),
+      reviewDocRef.collection('suggestions').get(),
+    ])
+
+    const savedReview = reviewSnap.data() as Review
+    const savedSuggs = suggsSnap.docs.map((d) => d.data() as FieldSuggestion)
+    savedSuggs.sort((a, b) => a.createdAt.toMillis() - b.createdAt.toMillis())
+
+    res.status(201).json({ status: 'ok', data: toReviewResponse(savedReview, savedSuggs) })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── GET /api/designs/:id/reviews ────────────────────────────────────────────
+
+export async function listReviews(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { id } = req.params
+
+    const mainSnap = await adminDb.collection(DESIGNS).doc(id).get()
+    if (!mainSnap.exists) return next(notFoundError('Design not found'))
+
+    const design = mainSnap.data() as Design
+    if (design.status === 'draft') {
+      if (!req.user || !design.author_ids.includes(req.user.uid)) {
+        return next(notFoundError('Design not found'))
+      }
+    }
+
+    // When a version is specified, filter by it without orderBy (avoids composite index).
+    // In both cases, sort in memory.
+    const versionNumber = req.query.version !== undefined
+      ? parseInt(req.query.version as string)
+      : NaN
+
+    let query: Query<DocumentData> = reviewsRef(id)
+    if (!isNaN(versionNumber)) {
+      query = query.where('versionNumber', '==', versionNumber)
+    }
+
+    const reviewsSnap = await query.get()
+    const reviewDocs = reviewsSnap.docs.map((d) => d.data() as Review)
+    reviewDocs.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis())
+
+    const reviews = await Promise.all(
+      reviewDocs.map(async (review) => {
+        const suggestions = await loadSuggestions(id, review.id)
+        return toReviewResponse(review, suggestions)
+      }),
+    )
+
+    res.status(200).json({ status: 'ok', data: reviews, count: reviews.length })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── GET /api/designs/:id/reviews/:reviewId ───────────────────────────────────
+
+export async function getReview(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { id, reviewId } = req.params
+
+    const reviewSnap = await reviewsRef(id).doc(reviewId).get()
+    if (!reviewSnap.exists) return next(notFoundError('Review not found'))
+
+    const review = reviewSnap.data() as Review
+    const suggestions = await loadSuggestions(id, reviewId)
+
+    res.status(200).json({ status: 'ok', data: toReviewResponse(review, suggestions) })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── POST /api/designs/:id/endorsements ──────────────────────────────────────
+
+export async function endorseDesign(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { id } = req.params
+    const callerId = req.user!.uid
+
+    let design: Design
+    try {
+      design = await requireReviewable(id, callerId)
+    } catch (err) {
+      return next(err as AppError)
+    }
+
+    const { comment } = req.body as CreateEndorsementBody
+    if (!comment?.trim()) {
+      return next(badRequest('comment is required for an endorsement.'))
+    }
+
+    const versionNumber = design.published_version
+
+    // Idempotent: return existing endorsement if already present for this user+version
+    const existingSnap = await reviewsRef(id)
+      .where('reviewerId', '==', callerId)
+      .where('versionNumber', '==', versionNumber)
+      .where('endorsement', '==', true)
+      .limit(1)
+      .get()
+
+    if (!existingSnap.empty) {
+      const existing = existingSnap.docs[0].data() as Review
+      res.status(200).json({ status: 'ok', data: toReviewResponse(existing, []) })
+      return
+    }
+
+    const now = FieldValue.serverTimestamp()
+    const reviewId = randomUUID()
+    const batch = adminDb.batch()
+
+    const reviewDocRef = reviewsRef(id).doc(reviewId)
+    batch.set(reviewDocRef, {
+      id: reviewId,
+      designId: id,
+      versionNumber,
+      reviewerId: callerId,
+      generalComment: comment.trim(),
+      readinessSignal: null,
+      endorsement: true,
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    batch.update(adminDb.collection(DESIGNS).doc(id), {
+      review_count: FieldValue.increment(1),
+      review_status:
+        design.review_status === 'unreviewed' ? 'under_review' : design.review_status,
+      updated_at: now,
+    })
+
+    await batch.commit()
+
+    const saved = (await reviewDocRef.get()).data() as Review
+    res.status(201).json({ status: 'ok', data: toReviewResponse(saved, []) })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── GET /api/designs/:id/endorsements ───────────────────────────────────────
+
+export async function listEndorsements(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { id } = req.params
+
+    const mainSnap = await adminDb.collection(DESIGNS).doc(id).get()
+    if (!mainSnap.exists) return next(notFoundError('Design not found'))
+
+    const snap = await reviewsRef(id).where('endorsement', '==', true).get()
+    const docs = snap.docs.map((d) => d.data() as Review)
+    docs.sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis())
+
+    const data = docs.map((r) => ({
+      reviewId: r.id,
+      reviewerId: r.reviewerId,
+      comment: r.generalComment,
+      versionNumber: r.versionNumber,
+      createdAt: r.createdAt.toDate().toISOString(),
+    }))
+
+    res.status(200).json({ status: 'ok', data, count: data.length })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// ─── GET /api/designs/:id/review-summary ─────────────────────────────────────
+
+export async function getReviewSummary(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { id } = req.params
+
+    const mainSnap = await adminDb.collection(DESIGNS).doc(id).get()
+    if (!mainSnap.exists) return next(notFoundError('Design not found'))
+
+    const design = mainSnap.data() as Design
+    if (design.status === 'draft') {
+      if (!req.user || !design.author_ids.includes(req.user.uid)) {
+        return next(notFoundError('Design not found'))
+      }
+    }
+
+    // Count reviews vs endorsements for the current published version
+    const reviewsSnap = await reviewsRef(id)
+      .where('versionNumber', '==', design.published_version)
+      .get()
+
+    let endorsementCount = 0
+    let reviewCount = 0
+    for (const doc of reviewsSnap.docs) {
+      const r = doc.data() as Review
+      if (r.endorsement) endorsementCount++
+      else reviewCount++
+    }
+
+    const contributorsSnap = await adminDb
+      .collection(DESIGNS)
+      .doc(id)
+      .collection('contributors')
+      .get()
+    const contributingReviewers = contributorsSnap.docs.map(
+      (d) => d.data() as ContributingReviewer,
+    )
+
+    const isLocked = design.status === 'locked' || design.execution_count > 0
+    const reviewable = design.status === 'published' && !isLocked
+
+    const summary: ReviewSummary = {
+      endorsementCount,
+      reviewCount,
+      contributingReviewers,
+      versionNumber: design.published_version,
+      isLocked,
+      reviewable,
+    }
+
+    res.status(200).json({ status: 'ok', data: summary })
+  } catch (err) {
+    next(err)
+  }
+}

--- a/backend/src/routes/designs.ts
+++ b/backend/src/routes/designs.ts
@@ -12,6 +12,14 @@ import {
   forkDesign,
   deleteDesign,
 } from '../controllers/designController'
+import {
+  submitReview,
+  listReviews,
+  getReview,
+  endorseDesign,
+  listEndorsements,
+  getReviewSummary,
+} from '../controllers/reviewController'
 
 const router = Router()
 
@@ -20,6 +28,10 @@ router.get('/', listDesigns)
 router.get('/:id', optionalAuth, getDesign)           // optionalAuth so authors see their draft state
 router.get('/:id/versions', optionalAuth, listDesignVersions)
 router.get('/:id/versions/:versionNum', optionalAuth, getDesignVersion)
+router.get('/:id/reviews', optionalAuth, listReviews)
+router.get('/:id/reviews/:reviewId', getReview)
+router.get('/:id/endorsements', listEndorsements)
+router.get('/:id/review-summary', optionalAuth, getReviewSummary)
 
 // Auth required for all mutations and personal views
 router.use(requireAuth)
@@ -30,5 +42,7 @@ router.patch('/:id', updateDesign)
 router.post('/:id/publish', publishDesign)
 router.post('/:id/fork', forkDesign)
 router.delete('/:id', deleteDesign)
+router.post('/:id/reviews', submitReview)
+router.post('/:id/endorsements', endorseDesign)
 
 export default router

--- a/backend/src/types/review.ts
+++ b/backend/src/types/review.ts
@@ -1,0 +1,96 @@
+import { Timestamp } from 'firebase-admin/firestore'
+
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+// Status of a Review document (distinct from the design's aggregate review_status)
+export type ReviewDocStatus  = 'active' | 'resolved' | 'superseded' | 'locked'
+export type SuggestionStatus = 'open' | 'accepted' | 'closed' | 'superseded' | 'locked'
+export type ReadinessSignal  = 'ready' | 'almost_ready' | 'needs_revision'
+export type SuggestionType   = 'suggestion' | 'issue' | 'question' | 'safety_concern'
+
+// ─── Firestore document shapes ────────────────────────────────────────────────
+// Path: designs/{designId}/reviews/{reviewId}
+
+export interface Review {
+  id: string
+  designId: string
+  versionNumber: number
+  reviewerId: string
+  generalComment: string | null
+  readinessSignal: ReadinessSignal | null
+  endorsement: boolean
+  status: ReviewDocStatus
+  createdAt: Timestamp
+  updatedAt: Timestamp
+}
+
+// Path: designs/{designId}/reviews/{reviewId}/suggestions/{suggestionId}
+
+export interface FieldSuggestion {
+  id: string
+  reviewId: string
+  designId: string
+  versionNumber: number
+  fieldRef: string | null       // null = proposed new field
+  newFieldName: string | null   // set when fieldRef is null
+  proposedText: string | null
+  comment: string | null
+  suggestionType: SuggestionType | null
+  status: SuggestionStatus
+  ownerReply: string | null
+  createdAt: Timestamp
+  updatedAt: Timestamp
+}
+
+// Path: designs/{designId}/contributors/{userId}
+
+export interface ContributingReviewer {
+  designId: string
+  userId: string
+  versionNumber: number
+  acceptedSuggestionIds: string[]
+  endorsedAndExecuted: boolean
+}
+
+// ─── API request bodies ───────────────────────────────────────────────────────
+
+export interface CreateSuggestionBody {
+  fieldRef?: string | null
+  newFieldName?: string | null
+  proposedText?: string | null
+  comment?: string | null
+  suggestionType?: SuggestionType | null
+}
+
+export interface CreateReviewBody {
+  generalComment?: string | null
+  readinessSignal?: ReadinessSignal | null
+  endorsement?: boolean
+  suggestions?: CreateSuggestionBody[]
+}
+
+export interface CreateEndorsementBody {
+  comment: string
+}
+
+// ─── API response types ───────────────────────────────────────────────────────
+
+export interface FieldSuggestionResponse extends Omit<FieldSuggestion, 'createdAt' | 'updatedAt'> {
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ReviewResponse extends Omit<Review, 'createdAt' | 'updatedAt'> {
+  createdAt: string
+  updatedAt: string
+  suggestions: FieldSuggestionResponse[]
+}
+
+export interface ReviewSummary {
+  endorsementCount: number
+  reviewCount: number
+  contributingReviewers: ContributingReviewer[]
+  versionNumber: number
+  isLocked: boolean
+  reviewable: boolean
+}

--- a/frontend/src/components/ReviewForm.tsx
+++ b/frontend/src/components/ReviewForm.tsx
@@ -1,0 +1,394 @@
+import { useState } from 'react'
+import { randomUUID } from '../lib/uuid'
+import { api } from '../lib/api'
+import type {
+  ReadinessSignal,
+  SuggestionType,
+  SuggestionEntry,
+  Review,
+} from '../types/review'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DESIGN_FIELD_OPTIONS: { value: string; label: string }[] = [
+  { value: 'title',                 label: 'Title' },
+  { value: 'summary',               label: 'Summary' },
+  { value: 'hypothesis',            label: 'Hypothesis' },
+  { value: 'steps',                 label: 'Procedure / Steps' },
+  { value: 'materials',             label: 'Materials' },
+  { value: 'research_questions',    label: 'Research Questions' },
+  { value: 'independent_variables', label: 'Independent Variables' },
+  { value: 'dependent_variables',   label: 'Dependent Variables' },
+  { value: 'controlled_variables',  label: 'Controlled Variables' },
+  { value: 'safety_considerations', label: 'Safety Considerations' },
+  { value: 'analysis_plan',         label: 'Analysis Plan' },
+  { value: 'ethical_considerations',label: 'Ethical Considerations' },
+  { value: '__new__',               label: 'New field (propose an addition)' },
+]
+
+const READINESS_OPTIONS: { value: ReadinessSignal; label: string }[] = [
+  { value: 'ready',          label: 'Ready to execute' },
+  { value: 'almost_ready',   label: 'Almost ready — minor issues' },
+  { value: 'needs_revision', label: 'Needs revision before executing' },
+]
+
+const SUGGESTION_TYPE_OPTIONS: { value: SuggestionType; label: string; selectedClass: string }[] = [
+  { value: 'suggestion',    label: 'Suggestion',    selectedClass: 'bg-blue-100 text-blue-700 ring-1 ring-blue-300' },
+  { value: 'issue',         label: 'Issue',         selectedClass: 'bg-red-100 text-red-700 ring-1 ring-red-300' },
+  { value: 'question',      label: 'Question',      selectedClass: 'bg-violet-100 text-violet-700 ring-1 ring-violet-300' },
+  { value: 'safety_concern',label: 'Safety concern',selectedClass: 'bg-amber-100 text-amber-700 ring-1 ring-amber-300' },
+]
+
+function newSuggestionEntry(): SuggestionEntry {
+  return {
+    localId:      randomUUID(),
+    fieldRef:     '',
+    useNewField:  false,
+    newFieldName: '',
+    proposedText: '',
+    comment:      '',
+    suggestionType: null,
+  }
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  designId: string
+  onSubmitted: (review: Review) => void
+  onCancel: () => void
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function ReviewForm({ designId, onSubmitted, onCancel }: Props) {
+  const [generalComment, setGeneralComment] = useState('')
+  const [endorsement, setEndorsement] = useState(false)
+  const [readinessSignal, setReadinessSignal] = useState<ReadinessSignal | null>(null)
+  const [suggestions, setSuggestions] = useState<SuggestionEntry[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  // ─── Suggestion helpers ──────────────────────────────────────────────────
+
+  function addSuggestion() {
+    setSuggestions((prev) => [...prev, newSuggestionEntry()])
+  }
+
+  function removeSuggestion(localId: string) {
+    setSuggestions((prev) => prev.filter((s) => s.localId !== localId))
+  }
+
+  function updateSuggestion(localId: string, patch: Partial<SuggestionEntry>) {
+    setSuggestions((prev) =>
+      prev.map((s) => (s.localId === localId ? { ...s, ...patch } : s)),
+    )
+  }
+
+  function toggleSuggestionType(localId: string, type: SuggestionType) {
+    setSuggestions((prev) =>
+      prev.map((s) =>
+        s.localId === localId
+          ? { ...s, suggestionType: s.suggestionType === type ? null : type }
+          : s,
+      ),
+    )
+  }
+
+  // ─── Validation ─────────────────────────────────────────────────────────
+
+  function validate(): string | null {
+    const trimmedComment = generalComment.trim()
+
+    if (!trimmedComment && !endorsement && suggestions.length === 0) {
+      return 'Add a general comment, field suggestions, or an endorsement.'
+    }
+    if (endorsement && !trimmedComment) {
+      return 'A comment is required when endorsing a design.'
+    }
+    for (let i = 0; i < suggestions.length; i++) {
+      const s = suggestions[i]
+      const fieldRef = s.useNewField ? null : s.fieldRef.trim()
+      const newFieldName = s.useNewField ? s.newFieldName.trim() : null
+      if (!fieldRef && !newFieldName) {
+        return `Suggestion ${i + 1}: select a field or enter a new field name.`
+      }
+      if (!s.proposedText.trim() && !s.comment.trim()) {
+        return `Suggestion ${i + 1}: add proposed text or a comment.`
+      }
+    }
+    return null
+  }
+
+  // ─── Submit ─────────────────────────────────────────────────────────────
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+
+    const validationError = validate()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const body = {
+        generalComment: generalComment.trim() || null,
+        endorsement,
+        readinessSignal,
+        suggestions: suggestions.map((s) => ({
+          fieldRef:      s.useNewField ? null : s.fieldRef || null,
+          newFieldName:  s.useNewField ? s.newFieldName.trim() || null : null,
+          proposedText:  s.proposedText.trim() || null,
+          comment:       s.comment.trim() || null,
+          suggestionType: s.suggestionType,
+        })),
+      }
+
+      const res = await api.post<{ status: string; data: Review }>(
+        `/api/designs/${designId}/reviews`,
+        body,
+      )
+      onSubmitted(res.data)
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to submit review. Please try again.'
+      setError(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // ─── Render ─────────────────────────────────────────────────────────────
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+
+      {/* General comment */}
+      <div>
+        <label className="block text-sm font-medium text-ink mb-1">
+          General comment
+        </label>
+        <textarea
+          rows={4}
+          value={generalComment}
+          onChange={(e) => setGeneralComment(e.target.value)}
+          placeholder="Share your overall assessment of this design's methodology, clarity, and scientific rigor…"
+          className="w-full input-sm resize-y"
+        />
+      </div>
+
+      {/* Readiness signal */}
+      <div>
+        <p className="text-sm font-medium text-ink mb-2">
+          Readiness signal <span className="text-muted font-normal">(optional)</span>
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {READINESS_OPTIONS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setReadinessSignal(readinessSignal === value ? null : value)}
+              className={`text-xs px-3 py-1.5 rounded-full border transition-colors ${
+                readinessSignal === value
+                  ? 'bg-dark text-surface border-dark'
+                  : 'bg-white text-muted border-surface-2 hover:border-secondary'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Endorsement */}
+      <label className="flex items-start gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={endorsement}
+          onChange={(e) => setEndorsement(e.target.checked)}
+          className="mt-0.5 accent-primary w-4 h-4 shrink-0"
+        />
+        <div>
+          <span className="text-sm font-medium text-ink">Endorse this design</span>
+          <p className="text-xs text-muted mt-0.5">
+            I consider this design methodologically sound and ready to execute.
+            Requires a general comment explaining your endorsement.
+          </p>
+        </div>
+      </label>
+
+      {/* Field suggestions */}
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-sm font-medium text-ink">
+            Field suggestions <span className="text-muted font-normal">(optional)</span>
+          </p>
+          <button
+            type="button"
+            onClick={addSuggestion}
+            className="text-xs text-primary hover:underline font-medium"
+          >
+            + Add suggestion
+          </button>
+        </div>
+
+        {suggestions.length > 0 && (
+          <div className="space-y-4">
+            {suggestions.map((s, i) => (
+              <SuggestionBlock
+                key={s.localId}
+                index={i}
+                entry={s}
+                onUpdate={(patch) => updateSuggestion(s.localId, patch)}
+                onToggleType={(type) => toggleSuggestionType(s.localId, type)}
+                onRemove={() => removeSuggestion(s.localId)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Error */}
+      {error && (
+        <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-3 pt-1">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="btn-primary text-sm disabled:opacity-50"
+        >
+          {submitting ? 'Submitting…' : 'Submit review'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={submitting}
+          className="btn-secondary text-sm"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}
+
+// ─── SuggestionBlock ──────────────────────────────────────────────────────────
+
+interface SuggestionBlockProps {
+  index: number
+  entry: SuggestionEntry
+  onUpdate: (patch: Partial<SuggestionEntry>) => void
+  onToggleType: (type: SuggestionType) => void
+  onRemove: () => void
+}
+
+function SuggestionBlock({ index, entry, onUpdate, onToggleType, onRemove }: SuggestionBlockProps) {
+  return (
+    <div className="rounded-xl border border-surface-2 bg-white p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted">
+          Suggestion {index + 1}
+        </p>
+        <button
+          type="button"
+          onClick={onRemove}
+          className="text-xs text-muted hover:text-red-600 transition-colors"
+        >
+          Remove
+        </button>
+      </div>
+
+      {/* Field reference */}
+      <div>
+        <label className="block text-xs font-medium text-ink mb-1">Field</label>
+        <select
+          value={entry.useNewField ? '__new__' : entry.fieldRef}
+          onChange={(e) => {
+            const val = e.target.value
+            if (val === '__new__') {
+              onUpdate({ useNewField: true, fieldRef: '' })
+            } else {
+              onUpdate({ useNewField: false, fieldRef: val })
+            }
+          }}
+          className="w-full input-sm"
+        >
+          <option value="">Select a field…</option>
+          {DESIGN_FIELD_OPTIONS.map(({ value, label }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+        {entry.useNewField && (
+          <input
+            type="text"
+            value={entry.newFieldName}
+            onChange={(e) => onUpdate({ newFieldName: e.target.value })}
+            placeholder="New field name…"
+            className="w-full input-sm mt-2"
+          />
+        )}
+      </div>
+
+      {/* Type chips */}
+      <div>
+        <p className="text-xs font-medium text-ink mb-1.5">
+          Type <span className="text-muted font-normal">(optional)</span>
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {SUGGESTION_TYPE_OPTIONS.map(({ value, label, selectedClass }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onToggleType(value)}
+              className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                entry.suggestionType === value
+                  ? selectedClass
+                  : 'bg-white text-muted border-surface-2 hover:border-secondary'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Proposed text */}
+      <div>
+        <label className="block text-xs font-medium text-ink mb-1">
+          Proposed text <span className="text-muted font-normal">(optional)</span>
+        </label>
+        <textarea
+          rows={2}
+          value={entry.proposedText}
+          onChange={(e) => onUpdate({ proposedText: e.target.value })}
+          placeholder="Suggest replacement text for this field…"
+          className="w-full input-sm resize-y"
+        />
+      </div>
+
+      {/* Comment */}
+      <div>
+        <label className="block text-xs font-medium text-ink mb-1">
+          Comment <span className="text-muted font-normal">(optional)</span>
+        </label>
+        <textarea
+          rows={2}
+          value={entry.comment}
+          onChange={(e) => onUpdate({ comment: e.target.value })}
+          placeholder="Explain your suggestion or ask a question…"
+          className="w-full input-sm resize-y"
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ReviewsSection.tsx
+++ b/frontend/src/components/ReviewsSection.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useState } from 'react'
+import { api } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
+import ReviewForm from './ReviewForm'
+import type { Review, ReviewSummary, ReadinessSignal, SuggestionType } from '../types/review'
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  designId: string
+  isAuthor: boolean
+  isPublished: boolean
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const READINESS_LABELS: Record<ReadinessSignal, string> = {
+  ready:          'Ready to execute',
+  almost_ready:   'Almost ready',
+  needs_revision: 'Needs revision',
+}
+
+const READINESS_COLORS: Record<ReadinessSignal, string> = {
+  ready:          'bg-green-50 text-green-700',
+  almost_ready:   'bg-yellow-50 text-yellow-700',
+  needs_revision: 'bg-red-50 text-red-700',
+}
+
+const SUGGESTION_TYPE_LABELS: Record<SuggestionType, string> = {
+  suggestion:    'Suggestion',
+  issue:         'Issue',
+  question:      'Question',
+  safety_concern:'Safety concern',
+}
+
+const SUGGESTION_TYPE_COLORS: Record<SuggestionType, string> = {
+  suggestion:    'bg-blue-50 text-blue-700',
+  issue:         'bg-red-50 text-red-700',
+  question:      'bg-violet-50 text-violet-700',
+  safety_concern:'bg-amber-50 text-amber-700',
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+  })
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function ReviewsSection({ designId, isAuthor, isPublished }: Props) {
+  const { user } = useAuth()
+  const [summary, setSummary] = useState<ReviewSummary | null>(null)
+  const [reviews, setReviews] = useState<Review[]>([])
+  const [loadingReviews, setLoadingReviews] = useState(false)
+  const [showForm, setShowForm] = useState(false)
+  const [showReviews, setShowReviews] = useState(false)
+  const [summaryError, setSummaryError] = useState('')
+
+  const canReview = !!user && !isAuthor && isPublished && (summary?.reviewable ?? false)
+  const alreadyReviewed = reviews.some((r) => r.reviewerId === user?.uid)
+
+  useEffect(() => {
+    loadSummary()
+  }, [designId])
+
+  async function loadSummary() {
+    try {
+      const res = await api.get<{ status: string; data: ReviewSummary }>(
+        `/api/designs/${designId}/review-summary`,
+      )
+      setSummary(res.data)
+    } catch {
+      setSummaryError('Could not load review summary.')
+    }
+  }
+
+  async function loadReviews() {
+    if (loadingReviews) return
+    setLoadingReviews(true)
+    try {
+      const res = await api.get<{ status: string; data: Review[] }>(
+        `/api/designs/${designId}/reviews`,
+      )
+      setReviews(res.data)
+    } catch {
+      // non-critical
+    } finally {
+      setLoadingReviews(false)
+    }
+  }
+
+  function handleToggleReviews() {
+    const next = !showReviews
+    setShowReviews(next)
+    if (next && reviews.length === 0) loadReviews()
+  }
+
+  function handleReviewSubmitted(review: Review) {
+    setReviews((prev) => [review, ...prev])
+    setShowForm(false)
+    setShowReviews(true)
+    setSummary((prev) =>
+      prev
+        ? {
+            ...prev,
+            reviewCount: review.endorsement ? prev.reviewCount : prev.reviewCount + 1,
+            endorsementCount: review.endorsement
+              ? prev.endorsementCount + 1
+              : prev.endorsementCount,
+          }
+        : prev,
+    )
+  }
+
+  if (!isPublished) return null
+
+  return (
+    <section className="card p-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4 mb-5">
+        <div>
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted mb-1">
+            Peer Reviews
+          </h2>
+          {summary && (
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+              <span className="text-ink">
+                <span className="font-medium">{summary.reviewCount}</span>{' '}
+                {summary.reviewCount === 1 ? 'review' : 'reviews'}
+              </span>
+              <span className="text-ink">
+                <span className="font-medium">{summary.endorsementCount}</span>{' '}
+                {summary.endorsementCount === 1 ? 'endorsement' : 'endorsements'}
+              </span>
+              {summary.isLocked && (
+                <span className="text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full self-center">
+                  Locked
+                </span>
+              )}
+            </div>
+          )}
+          {summaryError && (
+            <p className="text-xs text-muted">{summaryError}</p>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 shrink-0">
+          {(summary?.reviewCount ?? 0) + (summary?.endorsementCount ?? 0) > 0 && (
+            <button
+              onClick={handleToggleReviews}
+              className="btn-secondary text-xs"
+            >
+              {showReviews ? 'Hide' : 'View'} reviews
+            </button>
+          )}
+          {canReview && !alreadyReviewed && !showForm && (
+            <button
+              onClick={() => setShowForm(true)}
+              className="btn-primary text-xs"
+            >
+              Write a review
+            </button>
+          )}
+          {canReview && alreadyReviewed && !showForm && (
+            <button
+              onClick={() => setShowForm(true)}
+              className="btn-secondary text-xs"
+            >
+              Add another review
+            </button>
+          )}
+          {!user && isPublished && !isAuthor && (
+            <p className="text-xs text-muted italic">Sign in to leave a review</p>
+          )}
+        </div>
+      </div>
+
+      {/* Review form */}
+      {showForm && (
+        <div className="mb-5 rounded-xl border border-surface-2 bg-surface p-5">
+          <h3 className="text-sm font-semibold text-ink mb-4">Write a review</h3>
+          <ReviewForm
+            designId={designId}
+            onSubmitted={handleReviewSubmitted}
+            onCancel={() => setShowForm(false)}
+          />
+        </div>
+      )}
+
+      {/* Review list */}
+      {showReviews && (
+        <div className="space-y-4">
+          {loadingReviews && (
+            <div className="flex justify-center py-6">
+              <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
+
+          {!loadingReviews && reviews.length === 0 && (
+            <p className="text-sm text-muted text-center py-4">No reviews yet.</p>
+          )}
+
+          {reviews.map((review) => (
+            <ReviewCard key={review.id} review={review} />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state when no reviews and no form */}
+      {!showForm && !showReviews && summary &&
+        summary.reviewCount === 0 && summary.endorsementCount === 0 && (
+        <p className="text-sm text-muted">
+          No reviews yet.{' '}
+          {canReview
+            ? 'Be the first to review this design.'
+            : 'Share this design to invite feedback.'}
+        </p>
+      )}
+    </section>
+  )
+}
+
+// ─── ReviewCard ───────────────────────────────────────────────────────────────
+
+function ReviewCard({ review }: { review: Review }) {
+  const [expanded, setExpanded] = useState(false)
+  const hasSuggestions = review.suggestions.length > 0
+  const visibleSuggestions = expanded ? review.suggestions : review.suggestions.slice(0, 2)
+
+  return (
+    <div className="rounded-xl border border-surface-2 bg-white p-4 space-y-3">
+      {/* Meta row */}
+      <div className="flex flex-wrap items-center gap-2">
+        {review.endorsement && (
+          <span className="text-xs font-medium bg-green-50 text-green-700 px-2 py-0.5 rounded-full">
+            Endorsed
+          </span>
+        )}
+        {review.readinessSignal && (
+          <span
+            className={`text-xs font-medium px-2 py-0.5 rounded-full ${READINESS_COLORS[review.readinessSignal]}`}
+          >
+            {READINESS_LABELS[review.readinessSignal]}
+          </span>
+        )}
+        <span className="text-xs text-muted ml-auto">{formatDate(review.createdAt)}</span>
+      </div>
+
+      {/* General comment */}
+      {review.generalComment && (
+        <p className="text-sm text-gray-800 leading-relaxed">{review.generalComment}</p>
+      )}
+
+      {/* Suggestions */}
+      {hasSuggestions && (
+        <div className="space-y-2">
+          <p className="text-xs font-semibold text-muted uppercase tracking-widest">
+            {review.suggestions.length} field suggestion{review.suggestions.length !== 1 ? 's' : ''}
+          </p>
+          {visibleSuggestions.map((s) => (
+            <div
+              key={s.id}
+              className="rounded-lg border border-surface-2 bg-surface px-3 py-2 space-y-1"
+            >
+              <div className="flex flex-wrap items-center gap-1.5">
+                <span
+                  className="text-xs font-medium px-2 py-0.5 rounded-full bg-dark/5 text-ink"
+                  style={{ fontFamily: 'var(--font-mono)' }}
+                >
+                  {s.fieldRef ?? s.newFieldName}
+                  {s.newFieldName && !s.fieldRef && ' (new)'}
+                </span>
+                {s.suggestionType && (
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded-full ${SUGGESTION_TYPE_COLORS[s.suggestionType]}`}
+                  >
+                    {SUGGESTION_TYPE_LABELS[s.suggestionType]}
+                  </span>
+                )}
+              </div>
+              {s.proposedText && (
+                <p className="text-xs text-ink leading-relaxed">
+                  <span className="font-medium text-muted">Proposed: </span>
+                  {s.proposedText}
+                </p>
+              )}
+              {s.comment && (
+                <p className="text-xs text-muted leading-relaxed italic">{s.comment}</p>
+              )}
+            </div>
+          ))}
+          {review.suggestions.length > 2 && (
+            <button
+              onClick={() => setExpanded((p) => !p)}
+              className="text-xs text-primary hover:underline"
+            >
+              {expanded
+                ? 'Show fewer'
+                : `Show ${review.suggestions.length - 2} more suggestion${review.suggestions.length - 2 !== 1 ? 's' : ''}`}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/uuid.ts
+++ b/frontend/src/lib/uuid.ts
@@ -1,0 +1,3 @@
+export function randomUUID(): string {
+  return crypto.randomUUID()
+}

--- a/frontend/src/pages/DesignDetail.tsx
+++ b/frontend/src/pages/DesignDetail.tsx
@@ -6,6 +6,7 @@ import type { Design, DesignMaterial, ForkType, DesignVersionSummary, DesignVers
 import type { Material } from '../types/material'
 import MaterialCard from '../components/MaterialCard'
 import MaterialDetailModal from '../components/MaterialDetailModal'
+import ReviewsSection from '../components/ReviewsSection'
 
 const FORK_TYPES: { value: ForkType; label: string; description: string }[] = [
   { value: 'replication', label: 'Replication', description: 'Reproduce the same study to verify results' },
@@ -444,8 +445,9 @@ export default function DesignDetail() {
         </div>
       )}
 
-      {/* ── Two-column layout ── */}
+      {/* ── Two-column layout + reviews ── */}
       {!snapshotLoading && (
+        <>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
 
           {/* ────────── Main content (left, 2/3) ────────── */}
@@ -696,9 +698,35 @@ export default function DesignDetail() {
                 <button className="w-full btn-secondary text-sm justify-center" disabled>
                   Add to My Lab
                 </button>
-                <button className="w-full btn-secondary text-sm justify-center" disabled>
-                  Review Experiment
-                </button>
+                {design.status === 'published' && !isAuthor && user && (
+                  <button
+                    onClick={() =>
+                      document
+                        .getElementById('reviews-section')
+                        ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                    }
+                    className="w-full btn-secondary text-sm justify-center"
+                  >
+                    Review Experiment
+                  </button>
+                )}
+                {design.status === 'published' && isAuthor && (
+                  <button
+                    onClick={() =>
+                      document
+                        .getElementById('reviews-section')
+                        ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                    }
+                    className="w-full btn-secondary text-sm justify-center"
+                  >
+                    View Reviews
+                  </button>
+                )}
+                {design.status !== 'published' && (
+                  <button className="w-full btn-secondary text-sm justify-center" disabled>
+                    Review Experiment
+                  </button>
+                )}
                 {(canFork || design.status === 'published') && (
                   <button
                     onClick={canFork ? () => setShowForkModal(true) : undefined}
@@ -739,9 +767,6 @@ export default function DesignDetail() {
                           : 'Publish'}
                       </button>
                     )}
-                    <button className="w-full btn-secondary text-sm justify-center" disabled>
-                      View Reviews
-                    </button>
                   </div>
                 </>
               )}
@@ -812,6 +837,18 @@ export default function DesignDetail() {
             )}
           </div>
         </div>
+
+        {/* ── Reviews section (full-width, below columns) ── */}
+        {design.status === 'published' && (
+          <div id="reviews-section" className="mt-2">
+            <ReviewsSection
+              designId={design.id}
+              isAuthor={isAuthor}
+              isPublished={design.status === 'published'}
+            />
+          </div>
+        )}
+        </>
       )}
 
       {/* ── Edit warning modal ── */}

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -1,0 +1,63 @@
+export type ReviewDocStatus  = 'active' | 'resolved' | 'superseded' | 'locked'
+export type SuggestionStatus = 'open' | 'accepted' | 'closed' | 'superseded' | 'locked'
+export type ReadinessSignal  = 'ready' | 'almost_ready' | 'needs_revision'
+export type SuggestionType   = 'suggestion' | 'issue' | 'question' | 'safety_concern'
+
+export interface FieldSuggestion {
+  id: string
+  reviewId: string
+  designId: string
+  versionNumber: number
+  fieldRef: string | null
+  newFieldName: string | null
+  proposedText: string | null
+  comment: string | null
+  suggestionType: SuggestionType | null
+  status: SuggestionStatus
+  ownerReply: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface Review {
+  id: string
+  designId: string
+  versionNumber: number
+  reviewerId: string
+  generalComment: string | null
+  readinessSignal: ReadinessSignal | null
+  endorsement: boolean
+  status: ReviewDocStatus
+  createdAt: string
+  updatedAt: string
+  suggestions: FieldSuggestion[]
+}
+
+export interface ContributingReviewer {
+  designId: string
+  userId: string
+  versionNumber: number
+  acceptedSuggestionIds: string[]
+  endorsedAndExecuted: boolean
+}
+
+export interface ReviewSummary {
+  endorsementCount: number
+  reviewCount: number
+  contributingReviewers: ContributingReviewer[]
+  versionNumber: number
+  isLocked: boolean
+  reviewable: boolean
+}
+
+// ─── Form state types ─────────────────────────────────────────────────────────
+
+export interface SuggestionEntry {
+  localId: string           // React key only
+  fieldRef: string          // '' when useNewField is true
+  useNewField: boolean
+  newFieldName: string
+  proposedText: string
+  comment: string
+  suggestionType: SuggestionType | null
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of the peer review epic (#102) — everything needed for community members to submit reviews and for owners to see them.

**Backend (closes #103, #106):**
- New `review.ts` types: `Review`, `FieldSuggestion`, `ContributingReviewer`, `ReviewSummary` and all enums (`ReviewDocStatus`, `SuggestionStatus`, `ReadinessSignal`, `SuggestionType`)
- `reviewController.ts` with six endpoints wired into the existing designs router:
  - `POST /api/designs/:id/reviews` — full review with general comment, readiness signal, endorsement flag, and optional field suggestions; owner self-review blocked (403)
  - `GET /api/designs/:id/reviews[?version=n]` — list reviews, optionally version-filtered
  - `GET /api/designs/:id/reviews/:reviewId` — single review with its suggestions
  - `POST /api/designs/:id/endorsements` — standalone endorsement; idempotent per user/version, requires comment
  - `GET /api/designs/:id/endorsements` — list endorsements
  - `GET /api/designs/:id/review-summary` — counts, contributing reviewers, lock/reviewable status
- `review_count` incremented atomically with `FieldValue.increment`; `review_status` transitions from `unreviewed` → `under_review` on first review

**Frontend (closes #107):**
- `frontend/src/types/review.ts` — mirrors backend types with ISO string dates
- `ReviewForm` — general comment, readiness signal toggle chips, endorsement checkbox, dynamic suggestion blocks each with field selector, click-to-toggle type chips (suggestion / issue / question / safety concern), proposed text + comment
- `ReviewsSection` — summary stats, write/view toggle, inline form, expandable review cards
- `DesignDetail` — ReviewsSection added full-width below the two-column grid; sidebar buttons scroll to the section

## Test plan

- [ ] Publish a design as User A
- [ ] Sign in as User B, open the design — "Review Experiment" button visible
- [ ] Submit a review with general comment + readiness signal → review appears
- [ ] Add field suggestions with type chips → suggestions show in review card
- [ ] Submit with no content → validation error shown
- [ ] User A (owner) sees "View Reviews" not the review form
- [ ] Direct `POST /api/designs/:id/reviews` as owner → 403
- [ ] `GET /api/designs/:id/review-summary` returns correct counts
- [ ] Endorsement idempotency: submit twice as same user → same review returned
- [ ] Design not published → `POST /reviews` returns 403

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15