### PR TITLE
fix(reviews): one-review-per-user, collapsible suggestions, field display names

### DIFF
--- a/backend/src/types/review.ts
+++ b/backend/src/types/review.ts
@@ -93,4 +93,5 @@ export interface ReviewSummary {
   versionNumber: number
   isLocked: boolean
   reviewable: boolean
+  userHasReviewed?: boolean
 }

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -48,6 +48,7 @@ export interface ReviewSummary {
   versionNumber: number
   isLocked: boolean
   reviewable: boolean
+  userHasReviewed?: boolean
 }
 
 // ─── Form state types ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four UX/correctness fixes to the peer review system based on feedback:

- **One review per user per version** — users can no longer submit multiple reviews for the same experiment version. Clicking "Write a review" a second time now shows "Edit your review" and pre-fills the form; the backend performs an upsert (replaces suggestions, skips double-counting `review_count`). `review-summary` now includes `userHasReviewed` so the button state is accurate without loading all reviews.
- **"Add suggestion" button always below the list** — removed it from the floating header row; it now sits below the suggestion blocks unconditionally so reviewers never scroll back up to add more.
- **Collapsible suggestion blocks** — each suggestion container has a click-to-toggle header. Adding a new suggestion automatically collapses all previous blocks to reduce clutter; the new one opens expanded.
- **Human-readable field names in submitted reviews** — field chips on `ReviewCard` now map DB field refs to display names (e.g. `research_questions[2]` → `Research Questions #2`, `steps[new]` → `Procedure / Steps (new)`).

## Test plan

- [ ] Submit a review as User B → review card appears
- [ ] Click "Edit your review" → form opens pre-filled with previous comment/signal/endorsement
- [ ] Update and submit → existing card updates in-place, count unchanged
- [ ] Try `POST /reviews` twice as same user → second call returns 200 (not 201) with updated doc
- [ ] Add 3 suggestions one-by-one → each "Add suggestion" click collapses previous blocks
- [ ] Collapse/expand a block manually via header click
- [ ] Submit a review with field suggestions → chips show "Research Questions #1", "Procedure / Steps (new)", etc. — no raw DB keys

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15