### PR TITLE
UI housekeeping: display name, profile pic privacy, dropdown polish, Methodology rename

### DIFF
--- a/frontend/src/components/DesignForm.tsx
+++ b/frontend/src/components/DesignForm.tsx
@@ -368,7 +368,7 @@ export default function DesignForm({ values, onChange, lockedMethodology = false
     onChange({ ...values, [key]: val })
   }
 
-  // ── Steps ──────────────────────────────────────────────────────────────────
+  // ── Methodology steps ──────────────────────────────────────────────────────
   function addStep() {
     set('steps', [...values.steps, { step_number: values.steps.length + 1, instruction: '' }])
   }
@@ -529,9 +529,9 @@ export default function DesignForm({ values, onChange, lockedMethodology = false
         )}
       </div>
 
-      {/* ── 5. Steps ─────────────────────────────────────────────────────── */}
+      {/* ── 5. Methodology ───────────────────────────────────────────────── */}
       <div>
-        <FieldLabel label="Steps" required />
+        <FieldLabel label="Methodology" required />
         {values.steps.map((step, i) => (
           <div key={i} className="flex gap-2 mb-2">
             <span className="shrink-0 w-6 text-sm text-gray-400 pt-2">{step.step_number}.</span>
@@ -541,7 +541,7 @@ export default function DesignForm({ values, onChange, lockedMethodology = false
               value={step.instruction}
               disabled={lockedMethodology}
               onChange={(e) => updateStep(i, e.target.value)}
-              placeholder={`Step ${step.step_number} instruction`}
+              placeholder={`Step ${step.step_number}`}
               className="flex-1 input-sm resize-y"
             />
             {!lockedMethodology && values.steps.length > 1 && (

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { NavLink, Link } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import { fetchUserProfile } from '../lib/userProfileCache'
 
 const publicNavLinks = [
   { to: '/', label: 'Home', end: true },
@@ -15,7 +16,18 @@ export default function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false)
   const [adminOpen, setAdminOpen]   = useState(false)
   const [userOpen,  setUserOpen]    = useState(false)
+  const [profileDisplayName, setProfileDisplayName] = useState<string | null>(null)
   const { user, isAdmin, loading, signIn, signOut } = useAuth()
+
+  useEffect(() => {
+    if (user) {
+      fetchUserProfile(user.uid).then((p) => {
+        if (p) setProfileDisplayName(p.displayName)
+      })
+    } else {
+      setProfileDisplayName(null)
+    }
+  }, [user])
 
   const userNavLinks = user
     ? [
@@ -123,7 +135,7 @@ export default function Navbar() {
                     className="flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium
                                text-gray-700 hover:bg-gray-100 hover:text-gray-900 transition-colors"
                   >
-                    {user.displayName ?? user.email}
+                    {profileDisplayName ?? user.displayName ?? user.email}
                     <svg
                       className={`w-3.5 h-3.5 transition-transform ${userOpen ? 'rotate-180' : ''}`}
                       fill="none" stroke="currentColor" viewBox="0 0 24 24"

--- a/frontend/src/components/ReviewForm.tsx
+++ b/frontend/src/components/ReviewForm.tsx
@@ -33,7 +33,7 @@ const FIELD_OPTIONS: { value: string; label: string }[] = [
   { value: 'title',                  label: 'Title' },
   { value: 'summary',                label: 'Summary' },
   { value: 'hypothesis',             label: 'Hypothesis' },
-  { value: 'steps',                  label: 'Procedure / Steps' },
+  { value: 'steps',                  label: 'Methodology' },
   { value: 'materials',              label: 'Materials' },
   { value: 'research_questions',     label: 'Research Questions' },
   { value: 'independent_variables',  label: 'Independent Variables' },
@@ -591,8 +591,8 @@ function SuggestionBlock({
               proposedText={entry.proposedText}
               onSelectIndex={handleSubIndexSelect}
               onProposedChange={(text) => onUpdate({ proposedText: text })}
-              addNewLabel="Propose a new step"
-              proposedPlaceholder="Write the new step instruction…"
+              addNewLabel="Propose a new methodology step"
+              proposedPlaceholder="Write the new methodology step…"
               replacePlaceholder="Proposed replacement for this step…"
             />
           )}

--- a/frontend/src/components/ReviewsSection.tsx
+++ b/frontend/src/components/ReviewsSection.tsx
@@ -13,7 +13,7 @@ const FIELD_DISPLAY_NAMES: Record<string, string> = {
   title:                  'Title',
   summary:                'Summary',
   hypothesis:             'Hypothesis',
-  steps:                  'Procedure / Steps',
+  steps:                  'Methodology',
   materials:              'Materials',
   research_questions:     'Research Questions',
   independent_variables:  'Independent Variables',

--- a/frontend/src/components/UserProfileModal.tsx
+++ b/frontend/src/components/UserProfileModal.tsx
@@ -30,20 +30,12 @@ export default function UserProfileModal({ profile, onClose }: Props) {
       >
         {/* Header — avatar + name + admin badge */}
         <div className="flex items-center gap-4">
-          {profile.photoURL ? (
-            <img
-              src={profile.photoURL}
-              alt={profile.displayName}
-              className="w-14 h-14 rounded-full shrink-0 object-cover"
-            />
-          ) : (
-            <div
-              className="w-14 h-14 rounded-full flex items-center justify-center text-white text-xl font-bold shrink-0"
-              style={{ background: 'var(--color-dark)' }}
-            >
-              {initials}
-            </div>
-          )}
+          <div
+            className="w-14 h-14 rounded-full flex items-center justify-center text-white text-xl font-bold shrink-0"
+            style={{ background: 'var(--color-dark)' }}
+          >
+            {initials}
+          </div>
           <div className="min-w-0">
             <div className="flex items-center flex-wrap gap-2">
               <p

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -59,4 +59,28 @@
            focus:outline-none focus:ring-2 focus:ring-primary
            disabled:bg-surface disabled:text-muted;
   }
+
+  /* ── Selects ─────────────────────────────────────────── */
+  select.input-sm,
+  .select-styled {
+    @apply appearance-none pr-8 cursor-pointer;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238C7D8E' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.65rem center;
+  }
+
+  /* Filter selects (e.g. Experiments page) */
+  select.select-filter {
+    @apply appearance-none border rounded-xl px-3 py-2 text-sm bg-white
+           focus:outline-none focus:ring-2 focus:ring-primary pr-8 cursor-pointer
+           transition-colors;
+    border-color: var(--color-secondary);
+    color: var(--color-text);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238C7D8E' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.65rem center;
+  }
+  select.select-filter:hover {
+    border-color: var(--color-primary);
+  }
 }

--- a/frontend/src/pages/DesignDetail.tsx
+++ b/frontend/src/pages/DesignDetail.tsx
@@ -359,7 +359,7 @@ export default function DesignDetail() {
                 <select
                   value={selectorKey}
                   onChange={(e) => handleVersionSelect(e.target.value)}
-                  className="text-xs border border-surface-2 rounded-lg px-2 py-1 bg-white text-ink focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  className="input-sm text-xs py-1"
                   style={{ fontFamily: 'var(--font-mono)' }}
                 >
                   <option value="current">{currentOptionLabel}</option>
@@ -508,10 +508,10 @@ export default function DesignDetail() {
               </section>
             )}
 
-            {/* Procedure */}
+            {/* Methodology */}
             {viewedDesign.steps.length > 0 && (
               <section className="card p-6">
-                <SectionLabel>Procedure</SectionLabel>
+                <SectionLabel>Methodology</SectionLabel>
                 <ol className="space-y-5">
                   {viewedDesign.steps.map((step) => (
                     <li key={step.step_number} className="flex gap-4">

--- a/frontend/src/pages/Experiments.tsx
+++ b/frontend/src/pages/Experiments.tsx
@@ -65,7 +65,7 @@ export default function Experiments() {
         <select
           value={discipline}
           onChange={(e) => setDiscipline(e.target.value)}
-          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="select-filter"
         >
           <option value="">All disciplines</option>
           <option value="biology">Biology</option>
@@ -79,7 +79,7 @@ export default function Experiments() {
         <select
           value={difficulty}
           onChange={(e) => setDifficulty(e.target.value)}
-          className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="select-filter"
         >
           <option value="">All levels</option>
           {DIFFICULTY_OPTIONS.map((d) => (


### PR DESCRIPTION
Closes #116

## Changes

### Navbar display name
Fetch the user's Firestore profile on login and show their custom `displayName` instead of the raw Firebase Auth `displayName` (which is pulled from Google and shows their full legal name).

### Profile picture privacy
`UserProfileModal` no longer renders the user's `photoURL` to other users. Only the initials avatar is shown, protecting profile photo privacy.

### Dropdown polish
Added two CSS helpers in `index.css`:
- `select.input-sm` — all existing form selects (DesignForm, ReviewForm, DesignDetail version picker) now get a custom SVG chevron and `appearance-none` so the browser default arrow is hidden.
- `select.select-filter` — new class for filter selects (Experiments page); uses `--color-secondary` border with a hover to `--color-primary`.

### Steps → Methodology
Unified language everywhere the experiment procedure section appears:
| Location | Before | After |
|---|---|---|
| DesignForm section label | Steps | Methodology |
| DesignDetail section heading | Procedure | Methodology |
| ReviewForm field option | Procedure / Steps | Methodology |
| ReviewForm step picker labels | "Propose a new step" | "Propose a new methodology step" |
| ReviewsSection `FIELD_DISPLAY_NAMES` | Procedure / Steps | Methodology |

## Test plan

- [ ] Navbar shows custom display name (not Google full name)
- [ ] Clicking another user shows only initials, no photo
- [ ] Experiments filter dropdowns have clean chevron + brand border
- [ ] Create/Edit Design: steps section labelled "Methodology"
- [ ] Design viewer: section heading is "Methodology"
- [ ] Review form: field selector shows "Methodology"
- [ ] Existing reviews: field reference renders "Methodology"

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15