### PR TITLE
feat: email/password authentication (login + signup pages)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,8 @@ import EditDesign from './pages/EditDesign'
 import DesignDetail from './pages/DesignDetail'
 import Materials from './pages/Materials'
 import CreateMaterial from './pages/CreateMaterial'
+import Login from './pages/Login'
+import Signup from './pages/Signup'
 
 export default function App() {
   return (
@@ -19,6 +21,8 @@ export default function App() {
       <Route path="/" element={<Layout />}>
         {/* Public */}
         <Route index element={<Home />} />
+        <Route path="login" element={<Login />} />
+        <Route path="signup" element={<Signup />} />
         <Route path="experiments" element={<Experiments />} />
         <Route path="designs/:id" element={<DesignDetail />} />
 

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -17,7 +17,7 @@ export default function Navbar() {
   const [adminOpen, setAdminOpen]   = useState(false)
   const [userOpen,  setUserOpen]    = useState(false)
   const [profileDisplayName, setProfileDisplayName] = useState<string | null>(null)
-  const { user, isAdmin, loading, signIn, signOut } = useAuth()
+  const { user, isAdmin, loading, signOut } = useAuth()
 
   useEffect(() => {
     if (user) {
@@ -166,8 +166,8 @@ export default function Navbar() {
               </>
             ) : (
               <>
-                <button onClick={signIn} className="btn-secondary text-sm">Sign in</button>
-                <button onClick={signIn} className="btn-primary text-sm">Get started</button>
+                <Link to="/login" className="btn-secondary text-sm">Sign in</Link>
+                <Link to="/signup" className="btn-primary text-sm">Get started</Link>
               </>
             )}
           </div>
@@ -234,8 +234,8 @@ export default function Navbar() {
                 </>
               ) : (
                 <>
-                  <button onClick={signIn} className="btn-secondary w-full justify-center">Sign in</button>
-                  <button onClick={signIn} className="btn-primary w-full justify-center">Get started</button>
+                  <Link to="/login" onClick={() => setMobileOpen(false)} className="btn-secondary w-full justify-center">Sign in</Link>
+                  <Link to="/signup" onClick={() => setMobileOpen(false)} className="btn-primary w-full justify-center">Get started</Link>
                 </>
               )}
             </div>

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,8 +1,9 @@
-import { Navigate, Outlet } from 'react-router-dom'
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 
 export default function PrivateRoute() {
   const { user, loading } = useAuth()
+  const location = useLocation()
 
   if (loading) {
     return (
@@ -13,7 +14,7 @@ export default function PrivateRoute() {
   }
 
   if (!user) {
-    return <Navigate to="/" replace />
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />
   }
 
   return <Outlet />

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,270 @@
+import { useState, useEffect } from 'react'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+function mapFirebaseError(code: string): string {
+  switch (code) {
+    case 'auth/invalid-credential':
+    case 'auth/wrong-password':
+    case 'auth/user-not-found':
+      return 'Incorrect email or password.'
+    case 'auth/invalid-email':
+      return 'Please enter a valid email address.'
+    case 'auth/too-many-requests':
+      return 'Too many attempts. Please try again later or reset your password.'
+    case 'auth/user-disabled':
+      return 'This account has been disabled.'
+    default:
+      return 'Something went wrong. Please try again.'
+  }
+}
+
+export default function Login() {
+  const { user, signIn, signInWithEmail, resetPassword } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const from = (location.state as { from?: string })?.from ?? '/experiments'
+
+  const [email, setEmail]       = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError]       = useState<string | null>(null)
+  const [loading, setLoading]   = useState(false)
+
+  // Forgot-password inline flow
+  const [showForgot, setShowForgot]       = useState(false)
+  const [forgotEmail, setForgotEmail]     = useState('')
+  const [forgotSent, setForgotSent]       = useState(false)
+  const [forgotError, setForgotError]     = useState<string | null>(null)
+  const [forgotLoading, setForgotLoading] = useState(false)
+
+  // Redirect away if already signed in
+  useEffect(() => {
+    if (user) navigate(from, { replace: true })
+  }, [user, from, navigate])
+
+  async function handleEmailSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      await signInWithEmail(email, password)
+      navigate(from, { replace: true })
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code ?? ''
+      setError(mapFirebaseError(code))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleGoogleSignIn() {
+    setError(null)
+    setLoading(true)
+    try {
+      await signIn()
+      navigate(from, { replace: true })
+    } catch {
+      setError('Google sign-in failed. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleForgotSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setForgotError(null)
+    setForgotLoading(true)
+    try {
+      await resetPassword(forgotEmail)
+      setForgotSent(true)
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code ?? ''
+      if (code === 'auth/invalid-email') {
+        setForgotError('Please enter a valid email address.')
+      } else if (code === 'auth/user-not-found') {
+        // Don't reveal whether the account exists — just show success
+        setForgotSent(true)
+      } else {
+        setForgotError('Something went wrong. Please try again.')
+      }
+    } finally {
+      setForgotLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1
+            className="text-3xl font-bold mb-2"
+            style={{ fontFamily: 'var(--font-display)', color: 'var(--color-dark)' }}
+          >
+            Welcome back
+          </h1>
+          <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
+            Don't have an account?{' '}
+            <Link
+              to="/signup"
+              className="font-medium hover:underline"
+              style={{ color: 'var(--color-primary)' }}
+            >
+              Sign up
+            </Link>
+          </p>
+        </div>
+
+        <div className="card p-8 space-y-6">
+          {!showForgot ? (
+            <>
+              {/* Email / password form */}
+              <form onSubmit={handleEmailSubmit} className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1" style={{ color: 'var(--color-text)' }}>
+                    Email
+                  </label>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    autoComplete="email"
+                    className="input w-full"
+                    placeholder="you@example.com"
+                  />
+                </div>
+
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <label className="block text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+                      Password
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => { setShowForgot(true); setForgotEmail(email) }}
+                      className="text-xs hover:underline"
+                      style={{ color: 'var(--color-primary)' }}
+                    >
+                      Forgot password?
+                    </button>
+                  </div>
+                  <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    autoComplete="current-password"
+                    className="input w-full"
+                    placeholder="••••••••"
+                  />
+                </div>
+
+                {error && (
+                  <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">{error}</p>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="btn-primary w-full justify-center"
+                >
+                  {loading ? 'Signing in…' : 'Sign in'}
+                </button>
+              </form>
+
+              {/* Divider */}
+              <div className="flex items-center gap-3">
+                <div className="flex-1 h-px bg-gray-200" />
+                <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>or</span>
+                <div className="flex-1 h-px bg-gray-200" />
+              </div>
+
+              {/* Google */}
+              <button
+                onClick={handleGoogleSignIn}
+                disabled={loading}
+                className="btn-secondary w-full justify-center gap-2"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                    fill="#4285F4"
+                  />
+                  <path
+                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                    fill="#34A853"
+                  />
+                  <path
+                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                    fill="#FBBC05"
+                  />
+                  <path
+                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                    fill="#EA4335"
+                  />
+                </svg>
+                Continue with Google
+              </button>
+            </>
+          ) : (
+            /* Forgot password inline flow */
+            <div className="space-y-4">
+              <div>
+                <button
+                  type="button"
+                  onClick={() => { setShowForgot(false); setForgotSent(false); setForgotError(null) }}
+                  className="text-xs flex items-center gap-1 mb-4 hover:underline"
+                  style={{ color: 'var(--color-text-muted)' }}
+                >
+                  ← Back to sign in
+                </button>
+                <h2 className="text-lg font-semibold mb-1" style={{ color: 'var(--color-dark)' }}>
+                  Reset your password
+                </h2>
+                <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
+                  We'll send a reset link to your email address.
+                </p>
+              </div>
+
+              {forgotSent ? (
+                <div className="bg-green-50 text-green-800 text-sm px-4 py-3 rounded-lg">
+                  If an account exists for <strong>{forgotEmail}</strong>, a reset link has been sent. Check your inbox.
+                </div>
+              ) : (
+                <form onSubmit={handleForgotSubmit} className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-1" style={{ color: 'var(--color-text)' }}>
+                      Email
+                    </label>
+                    <input
+                      type="email"
+                      value={forgotEmail}
+                      onChange={(e) => setForgotEmail(e.target.value)}
+                      required
+                      autoComplete="email"
+                      className="input w-full"
+                      placeholder="you@example.com"
+                    />
+                  </div>
+
+                  {forgotError && (
+                    <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">{forgotError}</p>
+                  )}
+
+                  <button
+                    type="submit"
+                    disabled={forgotLoading}
+                    className="btn-primary w-full justify-center"
+                  >
+                    {forgotLoading ? 'Sending…' : 'Send reset link'}
+                  </button>
+                </form>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -1,0 +1,211 @@
+import { useState, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+function mapFirebaseError(code: string): string {
+  switch (code) {
+    case 'auth/email-already-in-use':
+      return 'An account with this email already exists.'
+    case 'auth/invalid-email':
+      return 'Please enter a valid email address.'
+    case 'auth/weak-password':
+      return 'Password must be at least 6 characters.'
+    case 'auth/too-many-requests':
+      return 'Too many attempts. Please try again later.'
+    default:
+      return 'Something went wrong. Please try again.'
+  }
+}
+
+export default function Signup() {
+  const { user, signIn, signUpWithEmail } = useAuth()
+  const navigate = useNavigate()
+
+  const [displayName, setDisplayName] = useState('')
+  const [email, setEmail]             = useState('')
+  const [password, setPassword]       = useState('')
+  const [confirm, setConfirm]         = useState('')
+  const [error, setError]             = useState<string | null>(null)
+  const [loading, setLoading]         = useState(false)
+
+  // Redirect away if already signed in
+  useEffect(() => {
+    if (user) navigate('/experiments', { replace: true })
+  }, [user, navigate])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    if (password !== confirm) {
+      setError('Passwords do not match.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      await signUpWithEmail(email, password, displayName.trim())
+      navigate('/experiments', { replace: true })
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code ?? ''
+      setError(mapFirebaseError(code))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleGoogleSignIn() {
+    setError(null)
+    setLoading(true)
+    try {
+      await signIn()
+      navigate('/experiments', { replace: true })
+    } catch {
+      setError('Google sign-in failed. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1
+            className="text-3xl font-bold mb-2"
+            style={{ fontFamily: 'var(--font-display)', color: 'var(--color-dark)' }}
+          >
+            Create your account
+          </h1>
+          <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
+            Already have an account?{' '}
+            <Link
+              to="/login"
+              className="font-medium hover:underline"
+              style={{ color: 'var(--color-primary)' }}
+            >
+              Sign in
+            </Link>
+          </p>
+        </div>
+
+        <div className="card p-8 space-y-6">
+          {/* Email / password form */}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1" style={{ color: 'var(--color-text)' }}>
+                Display name
+              </label>
+              <input
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                required
+                autoComplete="name"
+                className="input w-full"
+                placeholder="Jane Smith"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1" style={{ color: 'var(--color-text)' }}>
+                Email
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+                className="input w-full"
+                placeholder="you@example.com"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1" style={{ color: 'var(--color-text)' }}>
+                Password
+              </label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoComplete="new-password"
+                minLength={6}
+                className="input w-full"
+                placeholder="••••••••"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1" style={{ color: 'var(--color-text)' }}>
+                Confirm password
+              </label>
+              <input
+                type="password"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                required
+                autoComplete="new-password"
+                className="input w-full"
+                placeholder="••••••••"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="btn-primary w-full justify-center"
+            >
+              {loading ? 'Creating account…' : 'Create account'}
+            </button>
+          </form>
+
+          {/* Divider */}
+          <div className="flex items-center gap-3">
+            <div className="flex-1 h-px bg-gray-200" />
+            <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>or</span>
+            <div className="flex-1 h-px bg-gray-200" />
+          </div>
+
+          {/* Google */}
+          <button
+            onClick={handleGoogleSignIn}
+            disabled={loading}
+            className="btn-secondary w-full justify-center gap-2"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+              />
+            </svg>
+            Continue with Google
+          </button>
+
+          <p className="text-xs text-center" style={{ color: 'var(--color-text-muted)' }}>
+            By creating an account you agree to our terms of service and privacy policy.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **AuthContext**: adds `signInWithEmail`, `signUpWithEmail` (with force-refreshed ID token so `displayName` is in the JWT after `updateProfile`), and `resetPassword`
- **Login page** (`/login`): email + password form, inline forgot-password flow, Google sign-in; redirects to intended URL via `state.from`
- **Signup page** (`/signup`): display name + email + password + confirm form, Google option, friendly Firebase error messages
- **PrivateRoute**: redirect unauthenticated users to `/login` with `state={{ from: location.pathname }}`
- **Navbar**: "Sign in" / "Get started" now link to `/login` and `/signup`
- **App.tsx**: registers `/login` and `/signup` as public routes

## Test plan

- [ ] Unauthenticated user visits `/my-lab` → redirected to `/login`, after sign-in lands back on `/my-lab`
- [ ] Sign in with valid email + password → lands on `/experiments`
- [ ] Sign in with wrong password → shows "Incorrect email or password." inline
- [ ] Forgot password flow → enters email → success message shown
- [ ] Sign up with new email → account created, display name set, lands on `/experiments`
- [ ] Sign up with mismatched passwords → inline error before API call
- [ ] Sign up with existing email → shows "An account with this email already exists."
- [ ] Google sign-in on login/signup pages still works
- [ ] Navbar "Sign in" → `/login`, "Get started" → `/signup` (desktop + mobile)

https://claude.ai/code/session_013vkyE8nqUNoXd6aaBbmS15